### PR TITLE
5.3 fetch progress.  It is not Its, it is it's instead.  =)  La frase tiene sentido como "Es un"

### DIFF
--- a/5-network/03-fetch-progress/article.md
+++ b/5-network/03-fetch-progress/article.md
@@ -5,7 +5,7 @@ El método `fetch` permite rastrear el progreso de *descarga*.
 
 Ten en cuenta: actualmente no hay forma de que `fetch` rastree el progreso de *carga*. Para ese propósito, utiliza [XMLHttpRequest](info:xmlhttprequest), lo cubriremos más adelante.
 
-Para rastrear el progreso de la descarga, podemos usar la propiedad `response.body`. Su `ReadableStream`, un objeto especial que proporciona el cuerpo fragmento a fragmento, tal como viene. Las transmisiones legibles se describen en la especificación de la [API de transmisiones](https://streams.spec.whatwg.org/#rs-class).
+Para rastrear el progreso de la descarga, podemos usar la propiedad `response.body`. Es un `ReadableStream`, un objeto especial que proporciona el cuerpo fragmento a fragmento, tal como viene. Las transmisiones legibles se describen en la especificación de la [API de transmisiones](https://streams.spec.whatwg.org/#rs-class).
 
 A diferencia de `response.text()`, `response.json()` y otros métodos, `response.body` da control total sobre el proceso de lectura, y podemos contar cuánto se consume en cualquier momento.
 

--- a/5-network/03-fetch-progress/article.md
+++ b/5-network/03-fetch-progress/article.md
@@ -1,5 +1,5 @@
 
-# Fetch: progreso de la descarga
+# Fetch: Progreso de la descarga
 
 El método `fetch` permite rastrear el progreso de *descarga*.
 

--- a/5-network/03-fetch-progress/article.md
+++ b/5-network/03-fetch-progress/article.md
@@ -5,7 +5,7 @@ El método `fetch` permite rastrear el progreso de *descarga*.
 
 Ten en cuenta: actualmente no hay forma de que `fetch` rastree el progreso de *carga*. Para ese propósito, utiliza [XMLHttpRequest](info:xmlhttprequest), lo cubriremos más adelante.
 
-Para rastrear el progreso de la descarga, podemos usar la propiedad `response.body`. Es un `ReadableStream`, un objeto especial que proporciona el cuerpo fragmento a fragmento, tal como viene. Las transmisiones legibles se describen en la especificación de la [API de transmisiones](https://streams.spec.whatwg.org/#rs-class).
+Para rastrear el progreso de la descarga, podemos usar la propiedad `response.body`. Esta propiedad es un `ReadableStream`, un objeto especial que proporciona el cuerpo fragmento a fragmento, tal como viene. Las transmisiones legibles se describen en la especificación de la [API de transmisiones](https://streams.spec.whatwg.org/#rs-class).
 
 A diferencia de `response.text()`, `response.json()` y otros métodos, `response.body` da control total sobre el proceso de lectura, y podemos contar cuánto se consume en cualquier momento.
 


### PR DESCRIPTION
saltan más errorcillos cuando está online, 
y por suerte allí es fácil intercambiar idiomas para ver qué pasó.
 
@homero304 pasas a ser reviewer de este PR, y de paso quizas te guste empezar a hacer revisiones... 
y @vplentinax porque compartimos responsabilidad...

Lo demás, perfecto; links, code...