### PR TITLE
Corrección de título

### DIFF
--- a/1-js/06-advanced-functions/10-bind/article.md
+++ b/1-js/06-advanced-functions/10-bind/article.md
@@ -3,7 +3,7 @@ libs:
 
 ---
 
-# Función binding (vinculadora)
+# Función bind: vinculación de funciones
 
 
 Al pasar métodos de objeto como devoluciones de llamada, por ejemplo a `setTimeout`, se genera un problema conocido: "pérdida de `this`".


### PR DESCRIPTION
@vplentinax , cual te parece + claro?
Original:

> Function binding  

traduccion real:

> Vinculacion de funciones

Mal traducido:

> Función binding 

,( que no es nombre ni buena gramática)
Propuesto:

> Binding, vinculación de funciones  
o 
Function binding, vinculación de funciones 

( ¡ el verbo?  y traduccion) 
O creo mejor:

> Función bind, vinculacion de funciones
o 
Función bind

(BIND, que es el nombre de la funcion
