### PR TITLE
Juira (MDN:)

### DIFF
--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -15,7 +15,7 @@ En este aspecto, JavaScript es muy diferente a otro lenguaje llamado [Java](<htt
 ```smart header="¿Por qué se llama <u>Java</u>Script?"
 Cuando JavaScript fue creado, inicialmente tenía otro nombre: "LiveScript". Pero Java era muy popular en ese momento, así que se decidió que el posicionamiento de un nuevo lenguaje como un "Hermano menor" de Java ayudaría.
 
-Pero a medida que evolucionaba, JavaScript se convirtió en un lenguaje completamente independiente con su propia especificación llamada [ECMAScript] (https://es.wikipedia.org/wiki/ECMAScript), y ahora no tiene ninguna relación con Java.
+Pero a medida que evolucionaba, JavaScript se convirtió en un lenguaje completamente independiente con su propia especificación llamada [ECMAScript](https://es.wikipedia.org/wiki/ECMAScript), y ahora no tiene ninguna relación con Java.
 ```
 
 Hoy, JavaScript puede ejecutarse no solo en los navegadores, sino también en servidores o incluso en cualquier dispositivo que cuente con un programa especial llamado [El motor o intérprete de JavaScript](https://es.wikipedia.org/wiki/Int%C3%A9rprete_de_JavaScript).

--- a/1-js/02-first-steps/18-javascript-specials/article.md
+++ b/1-js/02-first-steps/18-javascript-specials/article.md
@@ -103,13 +103,13 @@ Más en: <info:variables> y <info:types>.
 
 Estamos utilizando un navegador como entorno de trabajo, por lo que las funciones básicas de la interfaz de usuario serán:
 
-[`prompt(question, [default])`](mdn:api/Window/prompt)
+[`prompt(question, [default])`](https://developer.mozilla.org/es/docs/Web/API/Window/prompt)
 : Hace una pregunta `question`, y devuelve lo que ingresó el visitante o`null` si presionaron "cancelar".
 
-[`confirm(question)`](mdn:api/Window/confirm)
+[`confirm(question)`](https://developer.mozilla.org/es/docs/Web/API/Window/confirm)
 : Hace una pregunta `question`, y sugiere elegir entre Aceptar y Cancelar. La eleccion se devuelve como booleano `true/false`.
 
-[`alert(message)`](mdn:api/Window/alert)
+[`alert(message)`](https://developer.mozilla.org/es/docs/Web/API/Window/alert)
 : Muestra un `message`.
 
 Todas estas funciones son *modales*, pausan la ejecución del código y evitan que el visitante interactúe con la página hasta que responda.
@@ -144,7 +144,7 @@ Asignaciones
 : He aqui una asignacion simple: `a = b` y una combinada `a *= 2`.
 
 Operador bit a bit
-: Los operadores bit a bit funcionan con enteros de 32 bits al más bajo nivel, el de bit: mire la [documentación](mdn:/JavaScript/Reference/Operators/Bitwise_Operators) cuando sea necesario.
+: Los operadores bit a bit funcionan con enteros de 32 bits al más bajo nivel, el de bit: mire la [documentación](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators) cuando sea necesario.
 
 Condicional
 : El único operador con 3 parametros: `cond ? resultA : resultB`. Sí `cond` es verdadera, devuelve `resultA`, de lo contrario `resultB`.

--- a/1-js/04-object-basics/02-object-copy/article.md
+++ b/1-js/04-object-basics/02-object-copy/article.md
@@ -133,7 +133,7 @@ clone.name = "Pete"; // cambiamos datos en él
 alert( user.name ); // John aún está en el objeto original
 ```
 
-También podemos usar el método [Object.assign](mdn:js/Object/assign) para ello.
+También podemos usar el método [Object.assign](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/assign) para ello.
 
 La sintaxis es:
 

--- a/1-js/04-object-basics/03-garbage-collection/article.md
+++ b/1-js/04-object-basics/03-garbage-collection/article.md
@@ -25,7 +25,7 @@ Simple, los valores "alcanzables" son aquellos que son accesibles o se pueden ut
 
     Por ejemplo, si hay un objeto en una variable local, y ese objeto tiene una propiedad que hace referencia a otro objeto, ese objeto se considera accesible. Y aquellos a los que hace referencia también son accesibles. Ejemplos detallados a seguir.
 
-Hay un proceso en segundo plano en el motor de JavaScript que se llama [recolector de basura] (https://es.wikipedia.org/wiki/Recolector_de_basura). Monitorea todos los objetos y elimina aquellos que se han vuelto inalcanzables.
+Hay un proceso en segundo plano en el motor de JavaScript que se llama [recolector de basura](https://es.wikipedia.org/wiki/Recolector_de_basura). Monitorea todos los objetos y elimina aquellos que se han vuelto inalcanzables.
 
 ## Un ejemplo sencillo
 

--- a/1-js/04-object-basics/08-symbol/article.md
+++ b/1-js/04-object-basics/08-symbol/article.md
@@ -161,7 +161,7 @@ alert( "Direct: " + user[id] );
 
 Esto forma parte del concepto general de "ocultamiento". Si otro script o si otra librería itera el objeto este no accesará a la  clave de Symbol.
 
-En contraste, [Object.assign](mdn:js/Object/assign) copia las claves tanto del string como las del symbol:
+En contraste, [Object.assign](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/assign) copia las claves tanto del string como las del symbol:
 
 ```js run
 let id = Symbol("id");
@@ -274,4 +274,4 @@ Symbols se utilizan principalmente en dos casos:
 
 2. Existen diversos symbols del sistema que utiliza Javascript, a los cuales podemos accesar por medio de `Symbol.*`. Podemos usarlos para alterar algunos comportamientos. Por ejemplo, más adelante en el tutorial, usaremos `Symbol.iterator` para [iterables](info:iterable), `Symbol.toPrimitive` para configurar [object-to-primitive conversion](info:object-toprimitive).
 
-Técnicamente, los symbols no están 100% ocultos. Existe un método incorporado [Object.getOwnPropertySymbols(obj)](mdn:js/Object/getOwnPropertySymbols) que nos permite obtener todos los symbols. También existe un método llamado [Reflect.ownKeys(obj)](mdn:js/Reflect/ownKeys) que devuelve *todas* las claves de un objeto, incluyendo las que son de tipo symbol. Por lo tanto, no están realmente ocultos, aunque la mayoría de las librerías, los métodos incorporados y las construcciones de sintaxis se adhieren a un acuerdo común de  que sí lo están. Y el que explícitamente llama a los métodos antes mencionados probablemente entiende bien lo que está haciendo.
+Técnicamente, los symbols no están 100% ocultos. Existe un método incorporado [Object.getOwnPropertySymbols(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertySymbols) que nos permite obtener todos los symbols. También existe un método llamado [Reflect.ownKeys(obj)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys) que devuelve *todas* las claves de un objeto, incluyendo las que son de tipo symbol. Por lo tanto, no están realmente ocultos, aunque la mayoría de las librerías, los métodos incorporados y las construcciones de sintaxis se adhieren a un acuerdo común de  que sí lo están. Y el que explícitamente llama a los métodos antes mencionados probablemente entiende bien lo que está haciendo.

--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -332,7 +332,7 @@ Ten en cuenta que un valor vacío o un string de solo espacios es tratado como `
 
 ```smart header="Comparación con `Object.is`"
 
-Hay un método especial incorporado [Object.is](mdn:js/Object/is) que compara valores como el `===`, pero es más confiable para dos casos extremos:
+Hay un método especial incorporado [Object.is](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/is) que compara valores como el `===`, pero es más confiable para dos casos extremos:
 
 1. Funciona con `NaN`: `Object.is(NaN, NaN) === true`, lo que es una buena cosa.
 2. Los valores `0` y `-0` son diferentes: `Object.is(0, -0) === false`. `false` es técnicamente correcto, porque internamente el número puede tener el bit de signo diferente incluso aunque todos los demás sean ceros.

--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -50,7 +50,7 @@ let guestList = "Invitados:  // Error: Unexpected token ILLEGAL
 
 Las comillas simples y dobles provienen de la creación de lenguaje en tiempos ancestrales, cuando la necesidad de múltiples líneas no era tomada en cuenta. Los backticks aparecieron mucho después y por ende son más versátiles.
 
-Los backticks además nos permiten especificar una "función de plantilla" antes del primer backtick. La sintaxis es: <code>func&#96;string&#96;</code>. La función `func` es llamada automáticamente, recibe el string y la expresión insertada y los puede procesar. Eso se llama "plantillas etiquetadas". Esta característica hace que sea más fácil implementar plantillas personalizadas, pero es raramente usada en la práctica. Puedes leer más sobre esto en [docs](mdn:/JavaScript/Reference/Template_literals#Tagged_templates). 
+Los backticks además nos permiten especificar una "función de plantilla" antes del primer backtick. La sintaxis es: <code>func&#96;string&#96;</code>. La función `func` es llamada automáticamente, recibe el string y la expresión insertada y los puede procesar. Eso se llama "plantillas etiquetadas". Esta característica hace que sea más fácil implementar plantillas personalizadas, pero es raramente usada en la práctica. Puedes leer más sobre esto en [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). 
 
 ## Caracteres especiales
 
@@ -144,7 +144,7 @@ Por favor notar que `str.length` es una propiedad numérica, no una función. No
 
 ## Accediendo caracteres
 
-Para acceder a un carácter en la posición `pos`, se debe usar paréntesis cuadrados `[pos]` o llamar al método [str.charAt(pos)](mdn:js/String/charAt). El primer carácter comienza desde la posición cero:
+Para acceder a un carácter en la posición `pos`, se debe usar paréntesis cuadrados `[pos]` o llamar al método [str.charAt(pos)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/charAt). El primer carácter comienza desde la posición cero:
 
 ```js run
 let str = `Hola`;
@@ -205,7 +205,7 @@ En la sección siguiente veremos más ejemplos de esto.
 
 ## Cambiando mayúsculas y minúsuculas
 
-Los métodos [toLowerCase()](mdn:js/String/toLowerCase) y [toUpperCase()](mdn:js/String/toUpperCase) cambian los caracteres a minúscula y mayúscula respectivamente:
+Los métodos [toLowerCase()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/toLowerCase) y [toUpperCase()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/toUpperCase) cambian los caracteres a minúscula y mayúscula respectivamente:
 
 ```js run
 alert('Interfaz'.toUpperCase()); // INTERFAZ
@@ -224,7 +224,7 @@ Existen muchas formas de buscar por subcadenas de caracteres dentro de una caden
 
 ### str.indexOf
 
-El primer método es [str.indexOf(substr, pos)](mdn:js/String/indexOf).
+El primer método es [str.indexOf(substr, pos)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/indexOf).
 
 Este busca un `substr` en `str`, comenzando desde la posición entregada `pos`, y retorna la posición donde es encontrada la coincidencia o `-1` en caso de no encontrar nada.
 
@@ -281,7 +281,7 @@ while ((pos = str.indexOf(target, pos + 1)) != -1) {
 ```
 
 ```smart header="`str.lastIndexOf(substr, position)`"
-Existe también un método similar [str.lastIndexOf(substr, position)](mdn:js/String/lastIndexOf) que busca desde el final del string hasta el comienzo.
+Existe también un método similar [str.lastIndexOf(substr, position)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/lastIndexOf) que busca desde el final del string hasta el comienzo.
 
 Este imprimirá las ocurrencias en orden invertido.
 ```
@@ -351,7 +351,7 @@ Ahora podemos ver este truco solo en código viejo, porque JavaScript moderno pr
 
 ### includes, startsWith, endsWith
 
-El método más moderno [str.includes(substr, pos)](mdn:js/String/includes) retorna `true/false` dependiendo si `str` contiene `substr` dentro.
+El método más moderno [str.includes(substr, pos)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/includes) retorna `true/false` dependiendo si `str` contiene `substr` dentro.
 
 Es la opción correcta si lo que necesitamos es encontrar el `substr` pero no necesitamos la posición.
 
@@ -368,7 +368,7 @@ alert('Midget'.includes('id')); // true
 alert('Midget'.includes('id', 3)); // false, desde la posición 3 no hay "id"
 ```
 
-Los métodos [str.startsWith](mdn:js/String/startsWith) (comienza con) y [str.endsWith](mdn:js/String/endsWith) (termina con) hacen exactamente lo que dicen:
+Los métodos [str.startsWith](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/startsWith) (comienza con) y [str.endsWith](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/endsWith) (termina con) hacen exactamente lo que dicen:
 
 ```js run
 alert('Widget'.startsWith('Wid')); // true, "Widget" comienza con "Wid"
@@ -538,7 +538,7 @@ Por suerte, todos los navegadores modernos (IE10- requiere adicionalmente la bib
 
 Este provee un método especial para comparar strings en distintos lenguajes, siguiendo sus reglas.
 
-El llamado [str.localeCompare(str2)](mdn:js/String/localeCompare):
+El llamado [str.localeCompare(str2)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/localeCompare):
 
 - Retorna `1` si `str` es mayor que `str2` de acuerdo a las reglas del lenguaje.
 - Retorna `-1` si `str` es menor que `str2`.
@@ -550,7 +550,7 @@ Por ejemplo:
 alert('Österreich'.localeCompare('Zealand')); // -1
 ```
 
-Este método tiene dos argumentos adicionales especificados en [la documentación](mdn:js/String/localeCompare), la cual le permite especificar el languaje (por defeto lo toma del entorno) y configura reglas adicionales como sensibilidad a las mayúsculas y minúsculas o si debe `"a"` y `"á"` ser tratadas como iguales, etc.
+Este método tiene dos argumentos adicionales especificados en [la documentación](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/localeCompare), la cual le permite especificar el languaje (por defeto lo toma del entorno) y configura reglas adicionales como sensibilidad a las mayúsculas y minúsculas o si debe `"a"` y `"á"` ser tratadas como iguales, etc.
 
 ## Internals, Unicode
 
@@ -578,7 +578,7 @@ Notar que los pares sustitutos no existían en el tiempo que JavaScript fue crea
 
 De hecho, tenemos un solo símbolo en cada string más arriba, pero el `length` (largo) muestra `2`.
 
-`String.fromCodePoint` y `str.codePointAt` son algunos métodos extraños que tratan con pares sustitutos. Aparecieron recientemente en el lenguaje. Antes de ellos, existían sólo [String.fromCharCode](mdn:js/String/fromCharCode) y [str.charCodeAt](mdn:js/String/charCodeAt). Estos métodos son actualmente lo mismo que `fromCodePoint/codePointAt`, pero no funcionan con pares sustitutos.
+`String.fromCodePoint` y `str.codePointAt` son algunos métodos extraños que tratan con pares sustitutos. Aparecieron recientemente en el lenguaje. Antes de ellos, existían sólo [String.fromCharCode](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/fromCharCode) y [str.charCodeAt](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/charCodeAt). Estos métodos son actualmente lo mismo que `fromCodePoint/codePointAt`, pero no funcionan con pares sustitutos.
 
 Obtener un símbolo puede ser dificil, ya que los pares substitutos son tratados como dos caracteres:
 
@@ -641,7 +641,7 @@ alert( s1 == s2 ); // false aunque los caracteres se ven idénticos (?!)
 
 Para resolver esto, existe un algoritmo de "normalización Unicode" que lleva cada cadena a la forma "normal".
 
-Este es implementado por [str.normalize()](mdn:js/String/normalize).
+Este es implementado por [str.normalize()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/normalize).
 
 ```js run
 alert('S\u0307\u0323'.normalize() == 'S\u0323\u0307'.normalize()); // true
@@ -674,6 +674,6 @@ Existen varios otros métodos útiles en cadenas:
 
 - `str.trim()` -- remueve ("recorta") espacios desde el comienzo y final de un string.
 - `str.repeat(n)` -- repite el string `n` veces.
-- ...y más. Mira el [manual](mdn:js/String) para más detalles.
+- ...y más. Mira el [manual](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String) para más detalles.
 
 Strings también tienen métodos con expresiones regulares para buscar/reemplazar. Es un tema importante, así que es explicado en su propia sección <info:regular-expressions> .

--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -36,7 +36,7 @@ Esto es porque `delete obj.key` borra el valor de `key`. Es todo lo que hace. Fu
 
 Por lo tanto, necesitamos utilizar métodos especiales.
 
-El método [arr.splice](mdn:js/Array/splice) funciona como una navaja suiza para arrays. Puede hacer todo: insertar, remover y remplazar elementos.
+El método [arr.splice](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/splice) funciona como una navaja suiza para arrays. Puede hacer todo: insertar, remover y remplazar elementos.
 
 La sintáxis es:
 
@@ -114,7 +114,7 @@ alert( arr ); // 1,2,3,4,5
 
 ### slice
 
-El método [arr.slice](mdn:js/Array/slice) es mucho más simple que `arr.splice`.
+El método [arr.slice](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/slice) es mucho más simple que `arr.splice`.
 
 La sintáxis es:
 
@@ -140,7 +140,7 @@ También podemos invocarlo sin argumentos: `arr.slice()` crea una copia de `arr`
 
 ### concat
 
-El método [arr.concat](mdn:js/Array/concat) crea un nuevo array que incluye valores de otros arrays y elementos adicionales.
+El método [arr.concat](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/concat) crea un nuevo array que incluye valores de otros arrays y elementos adicionales.
 
 La sintaxis es:
 
@@ -201,7 +201,7 @@ alert( arr.concat(arrayLike) ); // 1,2,something,else
 
 ## Iteración: forEach
 
-El método [arr.forEach](mdn:js/Array/forEach) permite ejecutar una función a cada elemento del array.
+El método [arr.forEach](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/forEach) permite ejecutar una función a cada elemento del array.
 
 La sintaxis:
 ```js
@@ -234,7 +234,7 @@ Ahora vamos a ver métodos que buscan elementos dentro de un array.
 
 ### indexOf/lastIndexOf e includes
 
-Los métodos [arr.indexOf](mdn:js/Array/indexOf), [arr.lastIndexOf](mdn:js/Array/lastIndexOf) y [arr.includes](mdn:js/Array/includes) tienen la misma sintaxis y hacen básicamente lo mismo que sus contrapartes de strings, pero operan sobre elementos en lugar de caracteres:
+Los métodos [arr.indexOf](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/indexOf), [arr.lastIndexOf](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/lastIndexOf) y [arr.includes](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/includes) tienen la misma sintaxis y hacen básicamente lo mismo que sus contrapartes de strings, pero operan sobre elementos en lugar de caracteres:
 
 - `arr.indexOf(item, from)` -- busca `item` comenzando desde el index `from`, y devuelve el index donde fue encontrado, es decir `-1`.
 - `arr.lastIndexOf(item, from)` -- igual que el anterior, pero busca de derecha a izquierda.
@@ -268,7 +268,7 @@ alert( arr.includes(NaN) );// true
 
 Imaginemos que tenemos un array de objetos. ¿Cómo podríamos encontrar un objeto con una condición específica?
 
-Para este tipo de casos es útil el método [arr.find(fn)](mdn:js/Array/find) 
+Para este tipo de casos es útil el método [arr.find(fn)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/find) 
 
 La sintáxis es:
 ```js
@@ -304,13 +304,13 @@ En la vida real los arrays de objetos son bastante comúnes por lo que el métod
 
 Ten en cuenta que en el ejemplo anterior le pasamos a `find` la función `item => item.id == 1` con un argumento. Esto es lo más común, otros argumentos son raramente usados en esta función.
 
-El método [arr.findIndex](mdn:js/Array/findIndex) es escencialmente lo mismo, pero devuelve el índice donde el elemento fue encontrado en lugar del elemento en sí y devuelve `-1` cuando no encuentra nada.
+El método [arr.findIndex](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/findIndex) es escencialmente lo mismo, pero devuelve el índice donde el elemento fue encontrado en lugar del elemento en sí y devuelve `-1` cuando no encuentra nada.
 
 ### filter
 
 El método `find` busca un único elemento (el primero) que haga a la función devolver `true`.
 
-Si existieran varios elementos que cumplen la condición, podemos usar [arr.filter(fn)](mdn:js/Array/filter).
+Si existieran varios elementos que cumplen la condición, podemos usar [arr.filter(fn)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/filter).
 
 La sintaxis es similar a `find`, pero `filter` devuelve un array con todos los elementos encontrados:
 
@@ -342,7 +342,7 @@ Pasamos ahora a los métodos que transforman y reordenan un array.
 
 ### map
 
-El método [arr.map](mdn:js/Array/map) es uno de los métodos más comunes y ampliamente usados. 
+El método [arr.map](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/map) es uno de los métodos más comunes y ampliamente usados. 
 
 Llama a la función para cada elemento del array y devuelve un array con los resultados.
 
@@ -363,7 +363,7 @@ alert(lengths); // 5,7,6
 
 ### sort(fn)
 
-Cuando usamos [arr.sort()](mdn:js/Array/sort), este ordena el propio array cambiando el orden de los elementos.
+Cuando usamos [arr.sort()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/sort), este ordena el propio array cambiando el orden de los elementos.
 
 También devuelve un nuevo array ordenado pero este usualmente se ignora ya que `arr` en sí mismo es modificado.
 
@@ -474,7 +474,7 @@ alert( paises.sort( (a, b) => a.localeCompare(b) ) ); // Andorra,Österreich,Vie
 
 ### reverse
 
-El método [arr.reverse](mdn:js/Array/reverse) revierte el orden de los elementos en `arr`.
+El método [arr.reverse](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/reverse) revierte el orden de los elementos en `arr`.
 
 Por ejemplo:
 
@@ -491,7 +491,7 @@ También devuelve el array `arr` después de revertir el orden.
 
 Analicemos una situación de la vida real. Estamos programando una app de mensajería y y el usuario ingresa una lista de receptores delimitada por comas: `Celina, David, Federico`. Pero para nosotros un array sería mucho más práctico que una simple string. ¿Cómo podemos hacer para obtener un array?
 
-El método [str.split(delim)](mdn:js/String/split) hace precisamente eso. Separa la string en un array siguiendo el delimitante dado `delim`.
+El método [str.split(delim)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/split) hace precisamente eso. Separa la string en un array siguiendo el delimitante dado `delim`.
 
 En el ejemplo de abajo, separamos por comas seguidas de espacio:
 
@@ -523,7 +523,7 @@ alert( str.split('') ); // t,e,s,t
 ```
 ````
 
-El llamado de [arr.join(glue)](mdn:js/Array/join) hace lo opuesto a `split`. Crea una string de `arr` elementos unidos con `glue` entre ellos.
+El llamado de [arr.join(glue)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/join) hace lo opuesto a `split`. Crea una string de `arr` elementos unidos con `glue` entre ellos.
 
 Por ejemplo:
 
@@ -541,7 +541,7 @@ Cuando necesitamos iterar sobre un array -- podemos usar `forEach`, `for` or `fo
 
 Cuando necesitamos iterar y devolver un valor por cada elemento -- podemos usar `map`.
 
-Los métodos [arr.reduce](mdn:js/Array/reduce) y [arr.reduceRight](mdn:js/Array/reduceRight) también pertenecen a ese grupo de acciones pero son un poco más complejos. Se los utiliza para calcular un único valor a partir del array.
+Los métodos [arr.reduce](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/reduce) y [arr.reduceRight](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/reduceRight) también pertenecen a ese grupo de acciones pero son un poco más complejos. Se los utiliza para calcular un único valor a partir del array.
 
 La sintaxis es la siguiente:
 
@@ -631,7 +631,7 @@ arr.reduce((sum, current) => sum + current);
 
 Por lo tanto siempre se recomienda especificar un valor inicial.
 
-El método [arr.reduceRight](mdn:js/Array/reduceRight) realiza lo mismo, pero va de derecha a izquierda.
+El método [arr.reduceRight](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/reduceRight) realiza lo mismo, pero va de derecha a izquierda.
 
 
 ## Array.isArray
@@ -645,7 +645,7 @@ alert(typeof {}); // object
 alert(typeof []); // object
 ```
 
-...Pero los arrays son utilizados tan a menudo que tienen un método especial: [Array.isArray(value)](mdn:js/Array/isArray). Este devuelve `true` si el `valor` es un array y `false` si no lo es.
+...Pero los arrays son utilizados tan a menudo que tienen un método especial: [Array.isArray(value)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/isArray). Este devuelve `true` si el `valor` es un array y `false` si no lo es.
 
 ```js run
 alert(Array.isArray({})); // false
@@ -739,7 +739,7 @@ Por favor tener en cuenta que `sort`, `reverse` y `splice` modifican el propio a
 
 Estos métodos son los más utilizados y cubren el 99% de los casos. Pero existen algunos más:
 
-- [arr.some(fn)](mdn:js/Array/some)/[arr.every(fn)](mdn:js/Array/every) comprueba el array.
+- [arr.some(fn)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/some)/[arr.every(fn)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/every) comprueba el array.
 
   La función `fn` es llamada para cada elemento del array de manera similar a `map`. Si alguno/todos los  resultados son `true`, devuelve `true`, si no, `false`.
     
@@ -754,13 +754,13 @@ Podemos usar `every` para comparar arrays:
   alert( arraysEqual([1, 2], [1, 2])); // true
   ```
 
-- [arr.fill(value, start, end)](mdn:js/Array/fill) -- llena el array repitiendo `value` desde el índice `start` hasta `end`.
+- [arr.fill(value, start, end)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/fill) -- llena el array repitiendo `value` desde el índice `start` hasta `end`.
 
-- [arr.copyWithin(target, start, end)](mdn:js/Array/copyWithin) -- copia sus elementos desde la posición `start` hasta la posición `end` en *si mismo*, a la posición `target` (reescribe lo existente).
+- [arr.copyWithin(target, start, end)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/copyWithin) -- copia sus elementos desde la posición `start` hasta la posición `end` en *si mismo*, a la posición `target` (reescribe lo existente).
 
-- [arr.flat(depth)](mdn:js/Array/flat)/[arr.flatMap(fn)](mdn:js/Array/flatMap) crea un nuevo array plano desde un array multidimensional .
+- [arr.flat(depth)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/flat)/[arr.flatMap(fn)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/flatMap) crea un nuevo array plano desde un array multidimensional .
 
-Para la lista completa, ver [manual](mdn:js/Array).
+Para la lista completa, ver [manual](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array).
 
 A primera vista puede parecer que hay demasiados métodos para aprender y un tanto difíciles de recordar. Pero con el tiempo se vuelve más fácil.
 

--- a/1-js/05-data-types/06-iterable/article.md
+++ b/1-js/05-data-types/06-iterable/article.md
@@ -197,7 +197,7 @@ Tanto los iterables como los array-like generalmente no son *matrices*, no tiene
 
 ## Array.from
 
-Existe un método universal [Array.from](mdn:js/Array/from) que toma un valor iterable o similar a una matriz y crea un `Array` ¨real¨ a partir de él. De esta manera podemos llamar y usar métodos que pertenecen a una matriz.
+Existe un método universal [Array.from](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/from) que toma un valor iterable o similar a una matriz y crea un `Array` ¨real¨ a partir de él. De esta manera podemos llamar y usar métodos que pertenecen a una matriz.
 
 Por ejemplo:
 

--- a/1-js/05-data-types/09-keys-values-entries/article.md
+++ b/1-js/05-data-types/09-keys-values-entries/article.md
@@ -19,9 +19,9 @@ Los objetos simples también admiten métodos similares, pero la sintaxis es un 
 
 Para objetos simples, los siguientes métodos están disponibles:
 
-- [Object.keys(obj)](mdn:js/Object/keys) -- devuelve un array de propiedades.
-- [Object.values(obj)](mdn:js/Object/values) -- devuelve un array de valores.
-- [Object.entries(obj)](mdn:js/Object/entries) -- devuelve un array de pares `[propiedad, valor]`.
+- [Object.keys(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/keys) -- devuelve un array de propiedades.
+- [Object.values(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/values) -- devuelve un array de valores.
+- [Object.entries(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/entries) -- devuelve un array de pares `[propiedad, valor]`.
 
 Tenga en cuenta las distinciones (en comparación con map, por ejemplo):
 
@@ -66,7 +66,7 @@ for (let value of Object.values(user)) {
 ```warn header="Object.keys/values/entries ignoran propiedades simbólicas"
 Al igual que un bucle `for..in`, estos métodos ignoran propiedades que utilizan `Symbol(...)` como nombre de propiedades.
 
-Normalmente, esto es conveniente. Pero si también queremos propiedades simbólicas, entonces hay un método aparte [Object.getOwnPropertySymbols](mdn:js/Object/getOwnPropertySymbols) que devuelve un array de únicamente propiedades simbólicas. También existe un método [Reflect.ownKeys(obj)](mdn:js/Reflect/ownKeys) que devuelve *todas* las propiedades.
+Normalmente, esto es conveniente. Pero si también queremos propiedades simbólicas, entonces hay un método aparte [Object.getOwnPropertySymbols](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertySymbols) que devuelve un array de únicamente propiedades simbólicas. También existe un método [Reflect.ownKeys(obj)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys) que devuelve *todas* las propiedades.
 ```
 
 

--- a/1-js/05-data-types/10-destructuring-assignment/article.md
+++ b/1-js/05-data-types/10-destructuring-assignment/article.md
@@ -95,7 +95,7 @@ alert(user.surname); // Smith
 ````
 
 ````smart header="Bucle con .entries()"
-En el capítulo anterior vimos el método [Object.entries(obj)](mdn:js/Object/entries).
+En el capítulo anterior vimos el método [Object.entries(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/entries).
 
 Podemos usarlo con la desestructuración para recorrer propiedades-y-valores de un objeto:
 

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -1,6 +1,6 @@
 # Fecha y Hora
 
-Ahora conozcamos un nuevo objeto incorporado de JS: [Date](mdn:js/Date). Este objeto contiene la fecha, la hora, y brinda métodos para administrarlas.
+Ahora conozcamos un nuevo objeto incorporado de JS: [Date](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date). Este objeto contiene la fecha, la hora, y brinda métodos para administrarlas.
 
 Por ejemplo, podemos usarlo para almacenar horas de creación/modificación, medir tiempo, o simplemente mostrar en pantalla la fecha actual.
 
@@ -80,16 +80,16 @@ Para crear un nuevo objeto `Date` se lo instancia con `new Date()` junto con uno
 
 Existen métodos que sirven para obtener el año, el mes, y los demás componentes a partir de un objeto de tipo `Date`:
 
-[getFullYear()](mdn:js/Date/getFullYear)
+[getFullYear()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getFullYear)
 : Devuelve el año (4 dígitos)
 
-[getMonth()](mdn:js/Date/getMonth)
+[getMonth()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getMonth)
 : Devuelve el mes, **de 0 a 11**.
 
-[getDate()](mdn:js/Date/getDate)
+[getDate()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getDate)
 : Devuelve el día del mes desde 1 a 31. Nótese que el nombre del método no es muy intuitivo.
 
-[getHours()](mdn:js/Date/getHours), [getMinutes()](mdn:js/Date/getMinutes), [getSeconds()](mdn:js/Date/getSeconds), [getMilliseconds()](mdn:js/Date/getMilliseconds)
+[getHours()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getHours), [getMinutes()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getMinutes), [getSeconds()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getSeconds), [getMilliseconds()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getMilliseconds)
 : Devuelve los componentes del horario correspondientes.
 
 ```warn header="No `getYear()`, sino `getFullYear()`"
@@ -98,12 +98,12 @@ Algunos motores de JavaScript poseen implementado un método no estándar llamad
 
 Además, podemos obtener un día de la semana:
 
-[getDay()](mdn:js/Date/getDay)
+[getDay()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getDay)
 : Devuelve el día de la semana, partiendo de `0` (Domingo) hasta `6` (Sábado). El primer día siempre es el Domingo. Por más que en algunos países no sea así, no se puede modificar.
 
 **Todos los métodos mencionados anteriormente devuelven los componentes correspondientes a la zona horaria local.**
 
-También existen sus contrapartes UTC, que devuelven el día, mes, año, y demás componentes, para la zona horaria UTC+0: [getUTCFullYear()](mdn:js/Date/getUTCFullYear), [getUTCMonth()](mdn:js/Date/getUTCMonth), [getUTCDay()](mdn:js/Date/getUTCDay). Solo debemos agregarle el `"UTC"` justo después de `"get"`.
+También existen sus contrapartes UTC, que devuelven el día, mes, año, y demás componentes, para la zona horaria UTC+0: [getUTCFullYear()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getUTCFullYear), [getUTCMonth()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth), [getUTCDay()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay). Solo debemos agregarle el `"UTC"` justo después de `"get"`.
 
 Si tu zona horaria está desplazada respecto de UTC el código de abajo va a mostrar horas diferentes:
 
@@ -120,10 +120,10 @@ alert( date.getUTCHours() );
 
 Además de los anteriormente mencionados, hay dos métodos especiales que no poseen una variante de UTC:
 
-[getTime()](mdn:js/Date/getTime)
+[getTime()](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/getTime)
 : Devuelve el _timestamp_ para una fecha determinada -- cantidad de milisegundos transcurridos a partir del 1° de Enero de 1970 UTC+0.
 
-[getTimezoneOffset()](mdn:js/Date/getTimezoneOffset)
+[getTimezoneOffset()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset)
 : Devuelve la diferencia entre UTC y el huso horario de la zona actual, en minutos:
 
     ```js run
@@ -137,14 +137,14 @@ Además de los anteriormente mencionados, hay dos métodos especiales que no pos
 
 Los siguientes métodos permiten establecer los componentes de fecha y hora:
 
-- [`setFullYear(year, [month], [date])`](mdn:js/Date/setFullYear)
-- [`setMonth(month, [date])`](mdn:js/Date/setMonth)
-- [`setDate(date)`](mdn:js/Date/setDate)
-- [`setHours(hour, [min], [sec], [ms])`](mdn:js/Date/setHours)
-- [`setMinutes(min, [sec], [ms])`](mdn:js/Date/setMinutes)
-- [`setSeconds(sec, [ms])`](mdn:js/Date/setSeconds)
-- [`setMilliseconds(ms)`](mdn:js/Date/setMilliseconds)
-- [`setTime(milliseconds)`](mdn:js/Date/setTime) (Establece la cantidad de segundos transcurridos desde 01.01.1970 GMT+0)
+- [`setFullYear(year, [month], [date])`](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/setFullYear)
+- [`setMonth(month, [date])`](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/setMonth)
+- [`setDate(date)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate)
+- [`setHours(hour, [min], [sec], [ms])`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours)
+- [`setMinutes(min, [sec], [ms])`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes)
+- [`setSeconds(sec, [ms])`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds)
+- [`setMilliseconds(ms)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds)
+- [`setTime(milliseconds)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime) (Establece la cantidad de segundos transcurridos desde 01.01.1970 GMT+0)
 
 A excepción de `setTime()`, todos los demás métodos poseen una variante UTC, por ejemplo: `setUTCHours()`.
 
@@ -381,7 +381,7 @@ Se pueden encontrar una gran cantidad de artículos acerca del motor V8 en <http
 
 ## Date.parse a partir de un string
 
-El método [Date.parse(str)](mdn:js/Date/parse) permite leer una fecha desde un string.
+El método [Date.parse(str)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date/parse) permite leer una fecha desde un string.
 
 El formato del string debe ser: `YYYY-MM-DDTHH:mm:ss.sssZ`, donde:
 
@@ -412,7 +412,7 @@ alert(date);
 
 ## Resumen
 
-- En JavaScript, la fecha y la hora se representan con el objeto [Date](mdn:js/Date). No es posible obtener sólo la fecha o sólo la hora: los objetos `Date` incluyen ambas.
+- En JavaScript, la fecha y la hora se representan con el objeto [Date](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Date). No es posible obtener sólo la fecha o sólo la hora: los objetos `Date` incluyen ambas.
 - Los meses se cuentan desde el cero (siendo Enero el mes cero).
 - Los días de la semana en `getDay()` también se cuentan desde el cero (que corresponde al día Domingo).
 - El objeto `Date` se autocorrije cuando recibe un componente fuera de rango. Es útil para sumar o restar días/meses/horas.
@@ -421,7 +421,7 @@ alert(date);
 
 Nótese que, a diferencia de otros sistemas, los _timestamps_ en JavaScript están representados en milisegundos (ms), no en segundos.
 
-Suele suceder que necesitemos tomar medidas de tiempo más precisas. En sí, JavaScript no tiene incorporada una manera de medir el tiempo en microsegundos (1 millonésima parte de segundo), pero la mayoría de los entornos de ejecución sí lo permiten. Por ejemplo, el navegador posee [performance.now()](mdn:api/Performance/now) que nos permite saber la cantidad de milisegundos que tarda una página en cargar, con una precisión de microsegundos (3 dígitos después del punto):
+Suele suceder que necesitemos tomar medidas de tiempo más precisas. En sí, JavaScript no tiene incorporada una manera de medir el tiempo en microsegundos (1 millonésima parte de segundo), pero la mayoría de los entornos de ejecución sí lo permiten. Por ejemplo, el navegador posee [performance.now()](https://developer.mozilla.org/es/docs/Web/API/Performance/now) que nos permite saber la cantidad de milisegundos que tarda una página en cargar, con una precisión de microsegundos (3 dígitos después del punto):
 
 ```js run
 alert(`La carga de la página comenzó hace ${performance.now()}ms`);

--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -401,7 +401,7 @@ Como podemos ver, `toJSON` es utilizado para ambos el llamado directo  `JSON.str
 
 ## JSON.parse
 
-Para decodificar un string JSON, necesitamos otro método llamado [JSON.parse](mdn:js/JSON/parse).
+Para decodificar un string JSON, necesitamos otro método llamado [JSON.parse](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/JSON/parse).
 
 La sintaxis:
 ```js
@@ -525,6 +525,6 @@ alert( schedule.meetups[1].date.getDate() ); // ¡Funciona!
 
 - JSON es un formato de datos que tiene su propio estándar independiente y librerías para la mayoría de los lenguajes de programación.
 - JSON admite objetos simples, arrays, strings, números, booleanos y `null`.
-- JavaScript proporciona métodos [JSON.stringify](mdn:js/JSON/stringify) para serializar en JSON y [JSON.parse](mdn: js/JSON/parse) para leer desde JSON.
+- JavaScript proporciona métodos [JSON.stringify](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/JSON/stringify) para serializar en JSON y [JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) para leer desde JSON.
 - Ambos métodos admiten funciones transformadoras para lectura / escritura inteligente.
 - Si un objeto tiene `toJSON`, entonces es llamado por` JSON.stringify`.

--- a/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
@@ -128,7 +128,7 @@ Acabamos de ver cómo obtener un array de la lista de parámetros.
 
 Pero a veces necesitamos hacer exactamente lo opuesto.
 
-Por ejemplo, existe una función nativa [Math.max](mdn:js/Math/max) que devuelve el número más grande de una lista:
+Por ejemplo, existe una función nativa [Math.max](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Math/max) que devuelve el número más grande de una lista:
 
 ```js run
 alert( Math.max(3, 5, 1) ); // 5

--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -119,7 +119,7 @@ Entonces, el contenedor pasa la llamada al método original, pero sin el context
 
 Vamos a solucionar esto: 
 
-Hay un método de función  especial incorporado [func.call(context, ...args)](mdn:js/Function/call) que permite llamar a una función que establece explícitamente `this`.
+Hay un método de función  especial incorporado [func.call(context, ...args)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Function/call) que permite llamar a una función que establece explícitamente `this`.
 
 La sintaxis es:
 
@@ -287,7 +287,7 @@ Hay dos cambios:
 
 En vez de `func.call(this, ...arguments)` nosotros podríamos usar `func.apply(this, arguments)`.
 
-La sintaxis del método incorporado [func.apply](mdn:js/Function/apply) es:
+La sintaxis del método incorporado [func.apply](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Function/apply) es:
 
 ```js
 func.apply(context, args)
@@ -337,7 +337,7 @@ function hash(args) {
 
 A partir de ahora, funciona solo en dos argumentos. Sería mejor si pudiera adherir (*glue*) cualquier número de `args`.
 
-La solución natural sería usar el método [arr.join](mdn:js/Array/join):
+La solución natural sería usar el método [arr.join](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/join):
 
 ```js
 function hash(args) {
@@ -410,8 +410,8 @@ Los decoradores se pueden ver como "características" o "aspectos" que se pueden
 
 Para implementar `cachingDecorator`, estudiamos los siguientes métodos:
 
-- [func.call(context, arg1, arg2...)](mdn:js/Function/call) -- llama a `func` con el contexto y argumentos dados.
-- [func.apply(context, args)](mdn:js/Function/apply) -- llama a `func` pasando `context` como `this` y array-like `args` en una lista de argumentos.
+- [func.call(context, arg1, arg2...)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Function/call) -- llama a `func` con el contexto y argumentos dados.
+- [func.apply(context, args)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Function/apply) -- llama a `func` pasando `context` como `this` y array-like `args` en una lista de argumentos.
 
 La *redirección de llamadas* genérica generalmente se realiza con `apply`:
 

--- a/1-js/06-advanced-functions/10-bind/article.md
+++ b/1-js/06-advanced-functions/10-bind/article.md
@@ -102,7 +102,7 @@ La siguiente solución garantiza que tal cosa no sucederá.
 
 ## Solución 2: bind
 
-Las funciones proporcionan un método incorporado [bind](mdn:js/Function/bind) que permite encontrar a `this`.
+Las funciones proporcionan un método incorporado [bind](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Function/bind) que permite encontrar a `this`.
 
 La sintaxis básica es:
 

--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -19,7 +19,7 @@ Aun no los vemos, porque generalmente no se muestran. Cuando creamos una propied
 
 Primero, veamos como conseguir estos indicadores.
 
-El método [Object.getOwnPropertyDescriptor](mdn:js/Object/getOwnPropertyDescriptor) permite consultar *toda* la información sobre una propiedad.
+El método [Object.getOwnPropertyDescriptor](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyDescriptor) permite consultar *toda* la información sobre una propiedad.
 
 La sintaxis es ésta:
 ```js
@@ -54,7 +54,7 @@ alert( JSON.stringify(descriptor, null, 2 ) );
 */
 ```
 
-Para cambiar los indicadores, podemos usar [Object.defineProperty](mdn:js/Object/defineProperty).
+Para cambiar los indicadores, podemos usar [Object.defineProperty](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/defineProperty).
 
 La sintaxis es ésta:
 
@@ -266,7 +266,7 @@ Object.defineProperty(user, "name", { value: "Pedro" });
 
 ## Object.defineProperties
 
-Hay un método [Object.defineProperties(obj, descriptors)](mdn:js/Object/defineProperties) que permite definir varias propiedades de una sola vez.
+Hay un método [Object.defineProperties(obj, descriptors)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/defineProperties) que permite definir varias propiedades de una sola vez.
 
 La sintaxis es esta:
 
@@ -292,7 +292,7 @@ Entonces, podemos asignar varias propiedades al mismo tiempo.
 
 ## Object.getOwnPropertyDescriptors
 
-Para obtener todos los descriptores al mismo tiempo, podemos usar el método [Object.getOwnPropertyDescriptors(obj)](mdn:js/Object/getOwnPropertyDescriptors).
+Para obtener todos los descriptores al mismo tiempo, podemos usar el método [Object.getOwnPropertyDescriptors(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyDescriptors).
 
 Junto con `Object.defineProperties` puede ser usado como una forma de "indicadores-conscientes" al clonar un objeto:
 
@@ -318,25 +318,25 @@ Los descriptores de propiedad trabajan al nivel de propiedades individuales.
 
 También hay métodos que limitan el acceso al objeto *completo*:
 
-[Object.preventExtensions(obj)](mdn:js/Object/preventExtensions)
+[Object.preventExtensions(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/preventExtensions)
 
 : Prohíbe añadir propiedades al objeto.
 
-[Object.seal(obj)](mdn:js/Object/seal)
+[Object.seal(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/seal)
 : Prohíbe añadir/eliminar propiedades, establece todas las propiedades existentes como `configurable: false`.
 
-[Object.freeze(obj)](mdn:js/Object/freeze)
+[Object.freeze(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/freeze)
 : Prohíbe añadir/eliminar/cambiar propiedades, establece todas las propiedades existentes como `configurable: false, writable: false`.
 
 Y también hay pruebas para ellos:
 
-[Object.isExtensible(obj)](mdn:js/Object/isExtensible)
+[Object.isExtensible(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/isExtensible)
 : Devuelve `false` si esta prohibido añadir propiedades, si no `true`.
 
-[Object.isSealed(obj)](mdn:js/Object/isSealed)
+[Object.isSealed(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/isSealed)
 : Devuelve `true` si añadir/eliminar propiedades está prohibido, y todas las propiedades existentes tienen `configurable: false`.
 
-[Object.isFrozen(obj)](mdn:js/Object/isFrozen)
+[Object.isFrozen(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/isFrozen)
 : Devuelve `true` si añadir/eliminar/cambiar propiedades está prohibido, y todas las propiedades son `configurable: false, writable: false`.
 
 Estos métodos son usados rara vez en la práctica.

--- a/1-js/08-prototypes/01-prototype-inheritance/article.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/article.md
@@ -287,7 +287,7 @@ for(let prop in rabbit) alert(prop); // jumps, despues eats
 */!*
 ```
 
-Si no queremos eso, y quisiéramos excluir las propiedades heredadas, hay un método incorporado [obj.hasOwnProperty(key)](mdn:js/Object/hasOwnProperty): devuelve `true` si `obj` tiene la propiedad interna (no heredada) llamada `key`.
+Si no queremos eso, y quisiéramos excluir las propiedades heredadas, hay un método incorporado [obj.hasOwnProperty(key)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/hasOwnProperty): devuelve `true` si `obj` tiene la propiedad interna (no heredada) llamada `key`.
 
 Entonces podemos filtrar las propiedades heredadas (o hacer algo más con ellas):
 

--- a/1-js/08-prototypes/04-prototype-methods/article.md
+++ b/1-js/08-prototypes/04-prototype-methods/article.md
@@ -7,9 +7,9 @@ En el primer capítulo de esta sección, mencionamos que existen métodos modern
 
 Los métodos modernos son:
 
-- [Object.create(proto, [descriptors])](mdn:js/Object/create) -- crea un objeto vacío con el "proto" dado como `[[Prototype]]` y descriptores de propiedad opcionales.
-- [Object.getPrototypeOf(obj)](mdn:js/Object/getPrototypeOf) -- devuelve el `[[Prototype]]` de `obj`.
-- [Object.setPrototypeOf(obj, proto)](mdn:js/Object/setPrototypeOf) -- establece el `[[Prototype]]` de `obj` en `proto`.
+- [Object.create(proto, [descriptors])](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/create) -- crea un objeto vacío con el "proto" dado como `[[Prototype]]` y descriptores de propiedad opcionales.
+- [Object.getPrototypeOf(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getPrototypeOf) -- devuelve el `[[Prototype]]` de `obj`.
+- [Object.setPrototypeOf(obj, proto)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/setPrototypeOf) -- establece el `[[Prototype]]` de `obj` en `proto`.
 
 Estos deben usarse en lugar de `__proto__`.
 
@@ -175,9 +175,9 @@ alert(Object.keys(chineseDictionary)); // hola,adios
 
 Los métodos modernos para configurar y acceder directamente al prototipo son:
 
-- [Object.create(proto, [descriptores])](mdn:js/Object/create) -- crea un objeto vacío con un `proto` dado como `[[Prototype]]` (puede ser `nulo`) y descriptores de propiedad opcionales.
-- [Object.getPrototypeOf(obj)](mdn:js/Object.getPrototypeOf) -- devuelve el `[[Prototype]]` de `obj` (igual que el getter de `__proto__`).
-- [Object.setPrototypeOf(obj, proto)](mdn:js/Object.setPrototypeOf) -- establece el `[[Prototype]]` de `obj` en `proto` (igual que el setter de `__proto__`).
+- [Object.create(proto, [descriptores])](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/create) -- crea un objeto vacío con un `proto` dado como `[[Prototype]]` (puede ser `nulo`) y descriptores de propiedad opcionales.
+- [Object.getPrototypeOf(obj)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf) -- devuelve el `[[Prototype]]` de `obj` (igual que el getter de `__proto__`).
+- [Object.setPrototypeOf(obj, proto)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) -- establece el `[[Prototype]]` de `obj` en `proto` (igual que el setter de `__proto__`).
 
 El getter/setter incorporado de `__proto__` no es seguro si queremos poner claves generadas por el usuario en un objeto. Aunque un usuario puede ingresar `"__proto __"` como clave, y habrá un error, con consecuencias levemente dañinas, pero generalmente impredecibles.
 
@@ -195,10 +195,10 @@ Podemos crear un objeto sin prototipo mediante `Object.create(null)`. Dichos obj
 
 Otros métodos:
 
-- [Object.keys(obj)](mdn:js/Object/keys) / [Object.values(obj)](mdn:js/Object/values) / [Object.entries(obj)](mdn:js/Object/entries): devuelve una arreglo de pares clave-valor: nombres/valores, de propiedades de cadena propios enumerables.
-- [Object.getOwnPropertySymbols(obj)](mdn:js/Object/getOwnPropertySymbols): devuelve un arreglo de todas las claves simbólicas propias.
-- [Object.getOwnPropertyNames(obj)](mdn:js/Object/getOwnPropertyNames): devuelve un arreglo de todas las claves de cadena propias.
-- [Reflect.ownKeys(obj)](mdn:js/Reflect/ownKeys): devuelve un arreglo de todas las claves propias.
-- [obj.hasOwnProperty(key)](mdn:js/Object/hasOwnProperty): devuelve `true` si `obj` tiene su propia clave (no heredada) llamada `key`.
+- [Object.keys(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/keys) / [Object.values(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/values) / [Object.entries(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/entries): devuelve una arreglo de pares clave-valor: nombres/valores, de propiedades de cadena propios enumerables.
+- [Object.getOwnPropertySymbols(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertySymbols): devuelve un arreglo de todas las claves simbólicas propias.
+- [Object.getOwnPropertyNames(obj)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyNames): devuelve un arreglo de todas las claves de cadena propias.
+- [Reflect.ownKeys(obj)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys): devuelve un arreglo de todas las claves propias.
+- [obj.hasOwnProperty(key)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/hasOwnProperty): devuelve `true` si `obj` tiene su propia clave (no heredada) llamada `key`.
 
 Todos los métodos que devuelven propiedades de objeto (como `Object.keys` y otros) - devuelven propiedades "propias". Si queremos heredados, podemos usar `for..in`.

--- a/1-js/09-classes/04-private-protected-properties-methods/article.md
+++ b/1-js/09-classes/04-private-protected-properties-methods/article.md
@@ -284,7 +284,7 @@ Con campos privados eso es imposible: `this['#name']` no funciona. Esa es una li
 
 ## Resumen
 
-En términos de POO, la delimitación de la interfaz interna de la externa se llama [encapsulamiento] (https://es.wikipedia.org/wiki/Encapsulamiento_(inform%C3%A1tica)).
+En términos de POO, la delimitación de la interfaz interna de la externa se llama [encapsulamiento](https://es.wikipedia.org/wiki/Encapsulamiento_(inform%C3%A1tica)).
 
 Ofrece los siguientes beneficios:
 

--- a/1-js/09-classes/06-instanceof/article.md
+++ b/1-js/09-classes/06-instanceof/article.md
@@ -104,7 +104,7 @@ Aquí está la ilustración de lo que `rabbit instanceof Animal` compara con `An
 
 ![](instanceof.svg)
 
-Por cierto, también hay un método [objA.isPrototypeOf(objB)] (mdn:js/object/isPrototypeOf), que devuelve `true` si `objA` está en algún lugar de la cadena de prototipos para `objB`. Por lo tanto, la prueba de `obj instanceof Class` se puede reformular como `Class.prototype.isPrototypeOf(obj)`.
+Por cierto, también hay un método [objA.isPrototypeOf(objB)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/object/isPrototypeOf), que devuelve `true` si `objA` está en algún lugar de la cadena de prototipos para `objB`. Por lo tanto, la prueba de `obj instanceof Class` se puede reformular como `Class.prototype.isPrototypeOf(obj)`.
 
 Es divertido, ¡pero el constructor `Class` en sí mismo no participa en el chequeo! Solo importa la cadena de prototipos y `Class.prototype`.
 
@@ -161,7 +161,7 @@ let arr = [];
 alert( objectToString.call(arr) ); // [object *!*Array*/!*]
 ```
 
-Aquí usamos [call](mdn:js/function/call) como se describe en el capítulo [](info:call-apply-decorators) para ejecutar la función `objectToString` en el contexto `this=arr`.
+Aquí usamos [call](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/function/call) como se describe en el capítulo [](info:call-apply-decorators) para ejecutar la función `objectToString` en el contexto `this=arr`.
 
 Internamente, el algoritmo `toString` examina `this` y devuelve el resultado correspondiente. Más ejemplos:
 

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -179,7 +179,7 @@ try {
 
 Exploremos un caso de uso de la vida real de `try..catch`.
 
-Como ya sabemos, JavaScript admite el método [JSON.parse(str)](mdn:js/JSON/parse) para leer valores codificados con JSON.
+Como ya sabemos, JavaScript admite el método [JSON.parse(str)](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/JSON/parse) para leer valores codificados con JSON.
 
 Por lo general, se utiliza para decodificar datos recibidos a través de la red, desde el servidor u otra fuente.
 
@@ -590,7 +590,7 @@ Imaginemos que tenemos un error fatal fuera de `try..catch`, y el script murió.
 
 ¿Hay alguna manera de reaccionar ante tales ocurrencias? Es posible que queramos registrar el error, mostrarle algo al usuario (normalmente no ve mensajes de error), etc.
 
-No hay ninguna en la especificación, pero los entornos generalmente lo proporcionan, porque es realmente útil. Por ejemplo, Node.js tiene [`process.on("uncaughtException")`](https://nodejs.org/api/process.html#process_event_uncaughtexception) para eso. Y en el navegador podemos asignar una función a la propiedad especial [window.onerror](mdn:api/GlobalEventHandlers/onerror), que se ejecutará en caso de un error no detectado.
+No hay ninguna en la especificación, pero los entornos generalmente lo proporcionan, porque es realmente útil. Por ejemplo, Node.js tiene [`process.on("uncaughtException")`](https://nodejs.org/api/process.html#process_event_uncaughtexception) para eso. Y en el navegador podemos asignar una función a la propiedad especial [window.onerror](https://developer.mozilla.org/es/docs/Web/API/GlobalEventHandlers/onerror), que se ejecutará en caso de un error no detectado.
 
 La sintaxis:
 

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -219,7 +219,7 @@ La primera promesa fue la más rápida, por lo que se vuelve resultado. En cuant
 
 ## Promise.any
 
-Es similar a `Promise.race`, pero espera solamente por la primera promesa cumplida y obtiene su resultado. Si todas la promesas fueron rechazadas, entonces la promesa que devuelve es rechazada con [`AggregateError`](mdn:js/AggregateError), un error especial que almacena los errores de todas las promesas en su propiedad `errors`.
+Es similar a `Promise.race`, pero espera solamente por la primera promesa cumplida y obtiene su resultado. Si todas la promesas fueron rechazadas, entonces la promesa que devuelve es rechazada con [`AggregateError`](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/AggregateError), un error especial que almacena los errores de todas las promesas en su propiedad `errors`.
 
 La sintaxis es:
 
@@ -316,7 +316,7 @@ Existen 6 métodos estáticos de la clase `Promise`:
     - `status`: `"fulfilled"` o `"rejected"`
     - `value` (si fulfilled) o `reason` (si rejected).
 3. `Promise.race(promises)` -- espera a la primera promesa que responda y aquel resultado o error se vuelve su resultado o error.
-4. `Promise.any(promises)` (método recientemente añadido) -- espera por la primera promesa que se cumpla y devuelve su resultado. Si todas las promesas son rechazadas, [`AggregateError`](mdn:js/AggregateError) se vuelve el error de `Promise.any`.
+4. `Promise.any(promises)` (método recientemente añadido) -- espera por la primera promesa que se cumpla y devuelve su resultado. Si todas las promesas son rechazadas, [`AggregateError`](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/AggregateError) se vuelve el error de `Promise.any`.
 5. `Promise.resolve(value)` -- crea una promesa resuelta con el "value" dado.
 6. `Promise.reject(error)` -- crea una promesa rechazada con el "error" dado.
 

--- a/1-js/13-modules/01-modules-intro/article.md
+++ b/1-js/13-modules/01-modules-intro/article.md
@@ -307,7 +307,7 @@ Los scripts externos que tengan `type="module"` son diferentes en dos aspectos:
     <script type="module" src="my.js"></script>
     ```
 
-2. Los scripts externos que se buscan desde otro origen (p.ej. otra sitio web) require encabezados [CORS](mdn:Web/HTTP/CORS), como se describe en el capítulo <info:fetch-crossorigin>. En otras palabras, si un script de módulo es extraido desde otro origen, el servidor remoto debe proporcionar un encabezado `Access-Control-Allow-Origin` permitiendo la búsqueda.
+2. Los scripts externos que se buscan desde otro origen (p.ej. otra sitio web) require encabezados [CORS](https://developer.mozilla.org/es/docs/Web/HTTP/Access_control_CORS), como se describe en el capítulo <info:fetch-crossorigin>. En otras palabras, si un script de módulo es extraido desde otro origen, el servidor remoto debe proporcionar un encabezado `Access-Control-Allow-Origin` permitiendo la búsqueda.
     ```html
     <!-- otro-sitio-web.com debe proporcionar Access-Control-Allow-Origin -->
     <!-- si no, el script no se ejecutará -->
@@ -346,7 +346,7 @@ Los navegadores antiguos no entienden `type = "module"`. Los scripts de un tipo 
 
 ## Herramientas de Ensamblaje
 
-En la vida real, los módulos de navegador rara vez se usan en su forma "pura". Por lo general, los agrupamos con una herramienta especial como [Webpack] (https://webpack.js.org/) y los implementamos en el servidor de producción.
+En la vida real, los módulos de navegador rara vez se usan en su forma "pura". Por lo general, los agrupamos con una herramienta especial como [Webpack](https://webpack.js.org/) y los implementamos en el servidor de producción.
 
 Uno de los beneficios de usar empaquetadores -- dan más control sobre cómo se resuelven los módulos, permitiendo módulos simples y mucho más, como los módulos CSS/HTML.
 
@@ -386,6 +386,6 @@ Para resumir, los conceptos centrales son:
 
 Cuando usamos módulos, cada módulo implementa la funcionalidad y la exporta. Luego usamos `import` para importarlo directamente donde sea necesario. El navegador carga y evalúa los scripts automáticamente.
 
-En la producción, las personas a menudo usan paquetes como [Webpack] (https://webpack.js.org) para agrupar módulos por rendimiento y otras razones.
+En la producción, las personas a menudo usan paquetes como [Webpack](https://webpack.js.org) para agrupar módulos por rendimiento y otras razones.
 
 En el próximo capítulo veremos más ejemplos de módulos y cómo se pueden exportar/importar cosas.

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -1024,7 +1024,7 @@ Esto nos permite crear propiedades y métodos "virtuales", implementar valores p
 
 También podemos atrapar un objeto múltiples veces en proxys diferentes, decorándolos con varios aspectos de funcionalidad.
 
-La API de [Reflect](mdn:/JavaScript/Reference/Global_Objects/Reflect) está diseñada para complementar [Proxy](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Proxy). Para cada trampa de `Proxy` hay una llamada `Reflect` con los mismos argumentos. Deberíamos usarlas para redirigir llamadas hacia los objetos target.
+La API de [Reflect](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/Reflect) está diseñada para complementar [Proxy](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Proxy). Para cada trampa de `Proxy` hay una llamada `Reflect` con los mismos argumentos. Deberíamos usarlas para redirigir llamadas hacia los objetos target.
 
 Los proxys tienen algunas limitaciones:
 

--- a/1-js/99-js-misc/05-bigint/article.md
+++ b/1-js/99-js-misc/05-bigint/article.md
@@ -126,5 +126,5 @@ Podemos usar tal código JSBI "tal como está" en motores que no soportan bigint
 
 ## Referencias
 
-- [MDN documentación BigInt](mdn:/JavaScript/Reference/Global_Objects/BigInt).
+- [MDN documentación BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt).
 - [Especificación](https://tc39.es/ecma262/#sec-bigint-objects).

--- a/2-ui/1-document/01-browser-environment/article.md
+++ b/2-ui/1-document/01-browser-environment/article.md
@@ -56,7 +56,7 @@ Por ejemplo, los scripts del lado del servidor que descargan páginas HTML y las
 ```
 
 ```smart header="CSSOM para los estilos"
-También hay una especificación separada, [CSS Object Model (CSSOM)] (https://www.w3.org/TR/cssom-1/) para las reglas y hojas de estilo CSS, que explica cómo se representan como objetos y cómo leerlos y escribirlos.
+También hay una especificación separada, [CSS Object Model (CSSOM)](https://www.w3.org/TR/cssom-1/) para las reglas y hojas de estilo CSS, que explica cómo se representan como objetos y cómo leerlos y escribirlos.
 
 CSSOM se usa junto con DOM cuando modificamos las reglas de estilo para el documento. Sin embargo, en la práctica, rara vez se requiere CSSOM, porque rara vez necesitamos modificar las reglas CSS de JavaScript (generalmente solo agregamos / eliminamos clases CSS, no modificamos sus reglas CSS), pero eso también es posible.
 ```

--- a/2-ui/1-document/02-dom-nodes/article.md
+++ b/2-ui/1-document/02-dom-nodes/article.md
@@ -210,7 +210,7 @@ Hay [12 tipos de nodos](https://dom.spec.whatwg.org/#node). En la práctica gene
 
 ## Véalo usted mismo
 
-Para ver la estructura del DOM en tiempo real, intente [Live DOM Viewer] (http://software.hixie.ch/utilities/js/live-dom-viewer/). Simplemente escriba el documento, y se mostrará como un DOM al instante.
+Para ver la estructura del DOM en tiempo real, intente [Live DOM Viewer](http://software.hixie.ch/utilities/js/live-dom-viewer/). Simplemente escriba el documento, y se mostrará como un DOM al instante.
 
 Otra forma de explorar el DOM es usando la herramienta para desarrolladores del navegador. En realidad, eso es lo que usamos cuando estamos desarrollando.
 

--- a/2-ui/1-document/08-styles-and-classes/article.md
+++ b/2-ui/1-document/08-styles-and-classes/article.md
@@ -296,7 +296,7 @@ Para manejar clases, hay dos propiedades del DOM:
 Para cambiar los estilos:
 
 - La propiedad `style` es un objeto con los estilos en `camelcase`. 
-Leer y escribir tiene el mismo significado que modificar propiedades individuales en el atributo `"style"`. Para ver cómo aplicar `important` y otras cosas raras, hay una lista de métodos en [MDN](mdn:api/CSSStyleDeclaration).
+Leer y escribir tiene el mismo significado que modificar propiedades individuales en el atributo `"style"`. Para ver cómo aplicar `important` y otras cosas raras, hay una lista de métodos en [MDN](https://developer.mozilla.org/es/docs/Web/API/CSSStyleDeclaration).
 
 - La propiedad `style.cssText` corresponde a todo el atributo `"style"`, la cadena completa de estilos.
 

--- a/2-ui/1-document/10-size-and-scroll-window/article.md
+++ b/2-ui/1-document/10-size-and-scroll-window/article.md
@@ -85,7 +85,7 @@ Los elementos regulares se pueden desplazar cambiando `scrollTop/scrollLeft`.
 
 Nosotros podemos hacer lo mismo para la página usando `document.documentElement.scrollTop/Left` (excepto Safari, donde `document.body.scrollTop/Left` debería usarse en su lugar).
 
-Alternativamente, hay una solución más simple y universal: métodos especiales [window.scrollBy(x,y)](mdn:api/Window/scrollBy) y [window.scrollTo(pageX,pageY)](mdn:api/Window/scrollTo).
+Alternativamente, hay una solución más simple y universal: métodos especiales [window.scrollBy(x,y)](https://developer.mozilla.org/es/docs/Web/API/Window/scrollBy) y [window.scrollTo(pageX,pageY)](https://developer.mozilla.org/es/docs/Web/API/Window/scrollTo).
 
 - El método `scrollBy(x, y)` desplaza la página *en relación con su posición actual*. Por ejemplo, `scrollBy(0,10)` desplaza la página `10px` hacia abajo.
 
@@ -106,7 +106,7 @@ Estos métodos funcionan para todos los navegadores de la misma manera.
 
 ## scrollIntoView
 
-Para completar, cubramos un método más: [elem.scrollIntoView(top)](mdn:api/Element/scrollIntoView).
+Para completar, cubramos un método más: [elem.scrollIntoView(top)](https://developer.mozilla.org/es/docs/Web/API/Element/scrollIntoView).
 
 La llamada a `elem.scrollIntoView(top)` desplaza la página para hacer visible `elem`. Tiene un argumento:
 

--- a/2-ui/3-event-details/1-mouse-events-basics/article.md
+++ b/2-ui/3-event-details/1-mouse-events-basics/article.md
@@ -66,7 +66,7 @@ Los valores posibles para `event.button` son:
 
 La mayoría de los dispositivos de ratón sólo tienen los botones izquierdo y derecho, por lo que los valores posibles son `0` o `2`. Los dispositivos táctiles también generan eventos similares cuando se toca sobre ellos.
 
-También hay una propiedad `event.buttons` que guarda todos los botones presionados actuales en un solo entero, un bit por botón. En la práctica, esta propiedad es raramente utilizada. Puedes encontrar más detalles en [MDN](mdn:/api/MouseEvent/buttons) si alguna vez lo necesitas.
+También hay una propiedad `event.buttons` que guarda todos los botones presionados actuales en un solo entero, un bit por botón. En la práctica, esta propiedad es raramente utilizada. Puedes encontrar más detalles en [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons) si alguna vez lo necesitas.
 
 ```warn header="El obsoleto `event.which`"
 El código puede utilizar la propiedad `event.which` que es una forma antigua no estándar de obtener un botón con los valores posibles:

--- a/2-ui/99-ui-misc/02-selection-range/article.md
+++ b/2-ui/99-ui-misc/02-selection-range/article.md
@@ -264,7 +264,7 @@ Haga clic en los botones para ejecutar métodos en la selección, "resetExample"
 </script>
 ```
 
-También existen métodos para comparar rangos, pero rara vez se utilizan. Cuando los necesite, consulte el [spec](https://dom.spec.whatwg.org/#interface-range) o [MDN manual](mdn:/api/Range).
+También existen métodos para comparar rangos, pero rara vez se utilizan. Cuando los necesite, consulte el [spec](https://dom.spec.whatwg.org/#interface-range) o [MDN manual](https://developer.mozilla.org/es/docs/Web/API/Range).
 
 
 ## Selection

--- a/3-frames-and-windows/03-cross-window-communication/article.md
+++ b/3-frames-and-windows/03-cross-window-communication/article.md
@@ -235,7 +235,7 @@ Aquí hay una lista de limitaciones:
 `allow-popups`
 : Permite `window.open` popups desde el `iframe`
 
-Consulta [el manual](mdn:/HTML/Element/iframe) para obtener más información.
+Consulta [el manual](https://developer.mozilla.org/es/docs/Web/HTML/Elemento/iframe) para obtener más información.
 
 El siguiente ejemplo muestra un iframe dentro de un entorno controlado con el conjunto de restricciones predeterminado: `<iframe sandbox src="...">`. Tiene algo de JavaScript y un formulario.
 
@@ -258,7 +258,7 @@ La interfaz tiene dos partes.
 
 ### postMessage
 
-La ventana que quiere enviar un mensaje llama al método [postMessage](mdn:api/Window.postMessage) de la ventana receptora. En otras palabras, si queremos enviar el mensaje a `win`, debemos llamar a `win.postMessage(data, targetOrigin)`.
+La ventana que quiere enviar un mensaje llama al método [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window.postMessage) de la ventana receptora. En otras palabras, si queremos enviar el mensaje a `win`, debemos llamar a `win.postMessage(data, targetOrigin)`.
 
 Argumentos:
 

--- a/4-binary/01-arraybuffer-binary-arrays/article.md
+++ b/4-binary/01-arraybuffer-binary-arrays/article.md
@@ -209,7 +209,7 @@ These methods allow us to copy typed arrays, mix them, create new arrays from ex
 
 ## DataView
 
-[DataView](mdn:/JavaScript/Reference/Global_Objects/DataView) is a special super-flexible "untyped" view over `ArrayBuffer`. It allows to access the data on any offset in any format.
+[DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) is a special super-flexible "untyped" view over `ArrayBuffer`. It allows to access the data on any offset in any format.
 
 - For typed arrays, the constructor dictates what the format is. The whole array is supposed to be uniform. The i-th number is `arr[i]`.
 - With `DataView` we access the data with methods like `.getUint8(i)` or `.getUint16(i)`. We choose the format at method call time instead of the construction time.

--- a/4-binary/03-blob/article.md
+++ b/4-binary/03-blob/article.md
@@ -119,7 +119,7 @@ Una alternativa a `URL.createObjectURL` es convertir un `Blob` en una cadena cod
 
 Esa codificación representa datos binarios como una cadena ultra segura de caractéres "legibles" con códigos ASCII desde el 0 al 64. Y lo que es más importante, podemos utilizar codificación en las "URLs de datos".
 
-Un [URL de datos](mdn:/http/Data_URIs) tiene la forma `data:[<mediatype>][;base64],<data>`. Podemos usar suficientes URLs por doquier, junto a URLs "regulares".
+Un [URL de datos](https://developer.mozilla.org/es/docs/Web/HTTP/Basics_of_HTTP/Datos_URIs) tiene la forma `data:[<mediatype>][;base64],<data>`. Podemos usar suficientes URLs por doquier, junto a URLs "regulares".
 
 Por ejemplo, aquí hay una sonrisa:
 
@@ -166,8 +166,8 @@ Podemos crear un `Blob` de una imagen, una parte de una imagen, o incluso hacer 
 
 Las operaciones de imágenes se hacen a través del elemento `<canvas>`:
 
-1. Dibuja una imagen (o una parte) en el canvas utilizando [canvas.drawImage](mdn:/api/CanvasRenderingContext2D/drawImage).
-2. Llama el método de canvas [.toBlob(callback, format, quality)](mdn:/api/HTMLCanvasElement/toBlob) que crea un `Blob` y llama el `callback` cuando termina.
+1. Dibuja una imagen (o una parte) en el canvas utilizando [canvas.drawImage](https://developer.mozilla.org/es/docs/Web/API/CanvasRenderingContext2D/drawImage).
+2. Llama el método de canvas [.toBlob(callback, format, quality)](https://developer.mozilla.org/es/docs/Web/API/HTMLCanvasElement/toBlob) que crea un `Blob` y llama el `callback` cuando termina.
 
 En el ejemplo siguiente, un imagen se copia, pero no podemos cortarla o transformarla en el canvas hasta convertirla en blob:
 

--- a/5-network/07-url/article.md
+++ b/5-network/07-url/article.md
@@ -145,10 +145,10 @@ Aunque si usamos un string, necesitamos codificar/decodificar caracteres especia
 
 Existen funciones incorporadas para eso:
 
-- [encodeURI](mdn:/JavaScript/Reference/Global_Objects/encodeURI) - Codifica la URL como un todo.
-- [decodeURI](mdn:/JavaScript/Reference/Global_Objects/decodeURI) - La decodifica de vuelta.
-- [encodeURIComponent](mdn:/JavaScript/Reference/Global_Objects/encodeURIComponent) - Codifica un componente URL, como un parametro de busqueda, un hash, o un pathname.
-- [decodeURIComponent](mdn:/JavaScript/Reference/Global_Objects/decodeURIComponent) - La decodifica de vuelta.
+- [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) - Codifica la URL como un todo.
+- [decodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) - La decodifica de vuelta.
+- [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) - Codifica un componente URL, como un parametro de busqueda, un hash, o un pathname.
+- [decodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) - La decodifica de vuelta.
 
 Una pregunta natural es: "¿Cuál es la diferencia entre `encodeURIComponent` y `encodeURI`?¿Cuándo deberíamos usar una u otra?
 

--- a/5-network/08-xmlhttprequest/article.md
+++ b/5-network/08-xmlhttprequest/article.md
@@ -332,7 +332,7 @@ Existen 3 métodos para las cabeceras HTTP:
 
 ## POST, Formularios
 
-Para hacer una solicitud POST, podemos utilizar el objeto [FormData](mdn:api/FormData) nativo.
+Para hacer una solicitud POST, podemos utilizar el objeto [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) nativo.
 
 La sintaxis:
 

--- a/6-data-storage/02-localstorage/article.md
+++ b/6-data-storage/02-localstorage/article.md
@@ -214,7 +214,7 @@ También que `event.storageArea` contiene el objeto de almacenaje -- el evento e
 
 **Esto permite que distintas ventanas del mismo orígen puedan intercambiar mensajes.**
 
-Los navegadores modernos también soportan la [API de Broadcast channel API](mdn:/api/Broadcast_Channel_API), la API específica para la comunicación entre ventanas del mismo orígen. Es más completa, pero tiene menos soporte. Hay librerías que añaden polyfills para ésta API basados en `localStorage` para que se pueda utilizar en cualquier entorno.
+Los navegadores modernos también soportan la [API de Broadcast channel API](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API), la API específica para la comunicación entre ventanas del mismo orígen. Es más completa, pero tiene menos soporte. Hay librerías que añaden polyfills para ésta API basados en `localStorage` para que se pueda utilizar en cualquier entorno.
 
 ## Resumen
 

--- a/7-animation/3-js-animation/article.md
+++ b/7-animation/3-js-animation/article.md
@@ -96,7 +96,7 @@ El valor devuelto `requestId` se puede utilizar para cancelar la llamada:
 cancelAnimationFrame(requestId);
 ```
 
-El `callback` obtiene un argumento: el tiempo transcurrido desde el inicio de la carga de la página en microsegundos. Este tiempo también se puede obtener llamando a [performance.now()](mdn:api/Performance/now).
+El `callback` obtiene un argumento: el tiempo transcurrido desde el inicio de la carga de la página en microsegundos. Este tiempo también se puede obtener llamando a [performance.now()](https://developer.mozilla.org/es/docs/Web/API/Performance/now).
 
 Por lo general, el `callback` se ejecuta muy pronto, a menos que el CPU esté sobrecargado o la batería de la laptop esté casi descargada, o haya otra razón.
 

--- a/8-web-components/2-custom-elements/article.md
+++ b/8-web-components/2-custom-elements/article.md
@@ -115,7 +115,7 @@ customElements.define("time-formatted", TimeFormatted); // (2)
 ></time-formatted>
 ```
 
-1. The class has only one method `connectedCallback()` -- the browser calls it when `<time-formatted>` element is added to page (or when HTML parser detects it), and it uses the built-in [Intl.DateTimeFormat](mdn:/JavaScript/Reference/Global_Objects/DateTimeFormat) data formatter, well-supported across the browsers, to show a nicely formatted time.
+1. The class has only one method `connectedCallback()` -- the browser calls it when `<time-formatted>` element is added to page (or when HTML parser detects it), and it uses the built-in [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) data formatter, well-supported across the browsers, to show a nicely formatted time.
 2. We need to register our new element by `customElements.define(tag, class)`.
 3. And then we can use it everywhere.
 

--- a/9-regular-expressions/01-regexp-introduction/article.md
+++ b/9-regular-expressions/01-regexp-introduction/article.md
@@ -2,7 +2,7 @@
 
 Las expresiones regulares son patrones que proporcionan una forma poderosa de buscar y reemplazar texto.
 
-En JavaScript, están disponibles a través del objeto [RegExp](mdn:js/RegExp), además de integrarse en métodos de cadenas.
+En JavaScript, están disponibles a través del objeto [RegExp](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/RegExp), además de integrarse en métodos de cadenas.
 
 ## Expresiones Regulares
 


### PR DESCRIPTION
@vplentinax 

Elimina todos los links mdn: (unos 150) porque eran defectuosos (acordado con Ilya). 
Los reemplacé con URL completa, a ES si habia traducción.
 
También corrijo todos los espacios de más entre corchete y parentesis ` [ sitio ] ( http://sitio ) ` porque ahora se ven  con  error de formato.  

Probé todos los links desde dentro del editor, 
no me puse a buscar pagina y linea con el server local para probarlos, demoraria años

Lo importante es que como están AHORA online FALLAN  (links y formatos) 
y esto lo arregla
