### PR TITLE
Corregido error en el ejemplo de strings inmutables

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -196,7 +196,7 @@ Por ejemplo:
 ```js run
 let str = 'Hola';
 
-str = 'h' + str[1]; // reemplaza el string
+str = 'h' + str[1] + str[2] + str[3]; // reemplaza el string
 
 alert( str ); // hola
 ```


### PR DESCRIPTION
En el ejemplo de strings inmutables se indica que el string resultante es "hola" cuando en realidad es solo "ho" debido a que se está reemplazando la variable "str" por la 'h' y por str[1] únicamente. He añadido que se incluya también str[2] y str[3] para formar la palabra completa