### PR TITLE
Devolución incorrecta de 'alert' en ejemplo

### DIFF
--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -190,7 +190,7 @@ let promise = new Promise(resolve => {
 });
 
 *!*
-promise.then(alert); // muestra "Error: ¡Vaya!" después de 1 segundo
+promise.then(alert); // muestra "hecho!" después de 1 segundo
 */!*
 ```
 


### PR DESCRIPTION
Hola! 👋

En el artículo de **'Promesa'** entre los ejemplos que se dan del uso de estas, uno de los fragmentos indica: "Si solo nos interesan las terminaciones exitosas, entonces podemos proporcionar solo un argumento de función para `.then`".

Luego el ejemplo es:

```js
let promise = new Promise(resolve => {
  setTimeout(() => resolve("hecho!"), 1000);
});

promise.then(alert); // muestra "Error: ¡Vaya!" después de 1 segundo
```
Realmente ese `alert` muestra _"hecho!"_.