### PR TITLE
Text overflow in mobile version

### DIFF
--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -123,7 +123,7 @@ Otra característica de OR || operador es la evaluación de "el camino más cort
 
 Esto significa que `||` procesa sus argumentos hasta que se alcanza el primer valor verdadero, y luego el valor se devuelve inmediatamente, sin siquiera tocar el otro argumento.
 
-    La importancia de esta característica se vuelve obvia si un operando no es solo un valor, sino una expresión con un efecto secundario, como una asignación de variable o una llamada a función.
+La importancia de esta característica se vuelve obvia si un operando no es solo un valor, sino una expresión con un efecto secundario, como una asignación de variable o una llamada a función.
 
 En el siguiente ejemplo, solo se imprime el segundo mensaje:
 


### PR DESCRIPTION
I have corrected the **overflow of a text** that in markdown was taken as a code element, when it should be a paragraph.

![overflow-mobile](https://user-images.githubusercontent.com/93359372/183148817-c23f9bc8-4f1c-4837-a4b1-5a05f519d213.jpeg)

