### PR TITLE
Update article.md

### DIFF
--- a/1-js/04-object-basics/08-symbol/article.md
+++ b/1-js/04-object-basics/08-symbol/article.md
@@ -221,7 +221,7 @@ En Javascript, como podemos ver, eso es verdad para los global symbols.
 
 ### Symbol.keyFor
 
-Hemos visto que ara los global symbols, `Symbol.for(key)` devuelve un symbol por su nombre. Para hacer lo opuesto, -- devolver el nombre de un global symbol -- podemos usar: `Symbol.keyFor(sym)`.
+Hemos visto que para los global symbols, `Symbol.for(key)` devuelve un symbol por su nombre. Para hacer lo opuesto, -- devolver el nombre de un global symbol -- podemos usar: `Symbol.keyFor(sym)`.
 
 Por ejemplo:
 

--- a/1-js/04-object-basics/08-symbol/article.md
+++ b/1-js/04-object-basics/08-symbol/article.md
@@ -221,7 +221,7 @@ En Javascript, como podemos ver, eso es verdad para los global symbols.
 
 ### Symbol.keyFor
 
-Para los global symbols, no solo `Symbol.for(key)` devuelve un symbol por su nombre. Para hacer lo opuesto, -- devolver el nombre de  un global symbol -- podemos usar: `Symbol.keyFor(sym)`.
+Hemos visto que ara los global symbols, `Symbol.for(key)` devuelve un symbol por su nombre. Para hacer lo opuesto, -- devolver el nombre de un global symbol -- podemos usar: `Symbol.keyFor(sym)`.
 
 Por ejemplo:
 


### PR DESCRIPTION
Corrección de la traducción. La frase original en inglés es "We have seen that for global symbols, Symbol.for(key) returns a symbol by name"