### PR TITLE
Update article.md

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -122,7 +122,7 @@ delete user["likes birds"];
 
 Ahora todo está bien. Nota que el string dentro de los corchetes está adecuadamente entre comillas (cualquier tipo de comillas servirían).
 
-Los corchetes también nos proveen de una forma para obtener el nombre de la propiedad como resultado de cualquier expresión -- en lugar de una cadena literal --, como por ejemplo a traves de una variable:
+Los corchetes también brindan una forma de obtener el nombre de la propiedad desde el resultado de una expresión (a diferencia de la cadena literal). Por ejemplo, a través de una variable:
 
 ```js
 let key = "likes birds";

--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -122,7 +122,7 @@ delete user["likes birds"];
 
 Ahora todo está bien. Nota que el string dentro de los corchetes está adecuadamente entre comillas (cualquier tipo de comillas servirían).
 
-Las llaves también nos proveen de una forma para obtener la clave de la propiedad como resultado de cualquier expresión como una variable -- en lugar de una cadena literal -- de la siguiente manera:
+Los corchetes también nos proveen de una forma para obtener el nombre de la propiedad como resultado de cualquier expresión -- en lugar de una cadena literal --, como por ejemplo a traves de una variable:
 
 ```js
 let key = "likes birds";


### PR DESCRIPTION
Se propone un cambio sobre el siguiente párrafo que en inglés dice:  "Square brackets also provide a way to obtain the property name as the result of any expression – as opposed to a literal string – like from a variable as follows:"

Ya que el actual presentaba errores de traducción e interpretación y dificultaba la comprensión del concepto que se intentaba transmitir