### PR TITLE
Remove leftover English code block from translation

### DIFF
--- a/1-js/06-advanced-functions/10-bind/5-question-use-bind/solution.md
+++ b/1-js/06-advanced-functions/10-bind/5-question-use-bind/solution.md
@@ -42,6 +42,3 @@ askPassword(() => user.loginOk(), () => user.loginFail());
 Por lo general, eso también funciona y se ve bien.
 
 Aunque es un poco menos confiable en situaciones más complejas donde la variable `user` podría cambiar *después* de que se llama a `askPassword`, *antes* de que el visitante responde y llame a `() => user.loginOk ()`.
-
-
-It's a bit less reliable though in more complex situations where `user` variable might change *after* `askPassword` is called, but *before* the visitor answers and calls `() => user.loginOk()`. 


### PR DESCRIPTION
## What does this PR do?

Removes a leftover English paragraph that was already translated and should have been removed.

## Context

The English sentence:
> “It’s a bit less reliable though in more complex situations...”

...was already translated above but remained in the Spanish version by mistake.

- Before:
<img width="835" alt="Captura de pantalla 2025-05-18 a la(s) 10 56 51 a  m" src="https://github.com/user-attachments/assets/c3e1363e-c4c6-4ed8-be83-7df4b1616fae" />

- After:
<img width="922" alt="Captura de pantalla 2025-05-18 a la(s) 10 58 58 a  m" src="https://github.com/user-attachments/assets/1557ed24-ad8a-4e3b-b7a0-03839fcea4c9" />
