### PR TITLE
Correct variable name in comment translation

### DIFF
--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -259,7 +259,7 @@ Object.defineProperty(user, "name", {
   configurable: false
 });
 
-// No seremos capaces de cambiar usuario.nombre o sus identificadores
+// No seremos capaces de cambiar user.name o sus identificadores
 // Nada de esto funcionará:
 user.name = "Pedro";
 delete user.name;

--- a/1-js/07-object-properties/02-property-accessors/article.md
+++ b/1-js/07-object-properties/02-property-accessors/article.md
@@ -181,7 +181,7 @@ user.name = ""; // El nombre es demasiado corto...
 
 Entonces, el nombre es almacenado en la propiedad `_name`, y el acceso se hace a través de getter y setter.
 
-Técnicamente, el código externo todavía puede acceder al nombre directamente usando "usuario._nombre". Pero hay un acuerdo ampliamente conocido de que las propiedades que comienzan con un guión bajo "_" son internas y no deben ser manipuladas desde el exterior del objeto.
+Técnicamente, el código externo todavía puede acceder al nombre directamente usando `user._name`. Pero hay un acuerdo ampliamente conocido de que las propiedades que comienzan con un guión bajo `"_"` son internas y no deben ser manipuladas desde el exterior del objeto.
 
 
 ## Uso para compatibilidad


### PR DESCRIPTION
The property was incorrectly referred to as `usuario.nombre` in two places.
Changed to `user.name` to reflect the actual code.

Also fixed the Markdown formatting.

- Before:
![Captura de pantalla 2025-05-31 a la(s) 6 18 03 p  m](https://github.com/user-attachments/assets/6e837ed4-9c53-4e54-870d-cae9e8edf921)
![image](https://github.com/user-attachments/assets/cd45962c-ba08-4abe-8e65-e5ba74e58dc5)


- After:
![Captura de pantalla 2025-05-31 a la(s) 6 18 38 p  m](https://github.com/user-attachments/assets/a58019ad-152b-44b4-a0c4-d85863207d47)
![Captura de pantalla 2025-05-31 a la(s) 9 15 15 p  m](https://github.com/user-attachments/assets/723e0f53-5f9e-41cf-98b7-388eb9882695)
