### PR TITLE
Correccion de Truthy Falsy

### DIFF
--- a/1-js/02-first-steps/10-ifelse/6-rewrite-if-else-question/task.md
+++ b/1-js/02-first-steps/10-ifelse/6-rewrite-if-else-question/task.md
@@ -6,7 +6,7 @@ importance: 5
 
 Reescriba el `if..else` utilizando operadores ternarios múltiples`'?'`.
 
-Para legibilidad, es recomendad dividirlo en múltiples lineas de código.
+Por legibilidad, se recomienda dividirlo en múltiples lineas de código.
 
 ```js
 let message;

--- a/1-js/02-first-steps/10-ifelse/6-rewrite-if-else-question/task.md
+++ b/1-js/02-first-steps/10-ifelse/6-rewrite-if-else-question/task.md
@@ -6,7 +6,7 @@ importance: 5
 
 Reescriba el `if..else` utilizando operadores ternarios múltiples`'?'`.
 
-Por legibilidad, se recomienda dividirlo en múltiples lineas de código.
+Para mejor legibilidad, se recomienda dividirlo en múltiples lineas de código.
 
 ```js
 let message;

--- a/1-js/02-first-steps/10-ifelse/article.md
+++ b/1-js/02-first-steps/10-ifelse/article.md
@@ -37,13 +37,13 @@ La sentencia `if (…)` evalúa la expresión dentro de sus paréntesis y convie
 
 Recordemos las reglas de conversión del capítulo <info:type-conversions>:
 
-- El número `0`, un string vacío `""`, `null`, `undefined`, y `NaN`, se convierten en `false`. Por esto son llamados valores "falsos".
-- El resto de los valores se convierten en `true`, entonces los llamaremos valores "verdaderos".
+- Los valores: número `0`, string vacío `""`, `null`, `undefined`, y `NaN`, en un contexto booleano se convierten en `false`. Por ello, sin ser booleanos, se los conoce como valores "falsy".
+- El resto de los valores se convierten en `true`, y son valores que llamamos "truthy".
 
 Entonces, el código bajo esta condición nunca se ejecutaría:
 
 ```js
-if (0) { // 0 es falso
+if (0) { // 0 es falsy
   ...
 }
 ```
@@ -51,7 +51,7 @@ if (0) { // 0 es falso
 ...y dentro de esta condición siempre se ejecutará:
 
 ```js
-if (1) { // 1 es verdadero
+if (1) { // 1 es truthy
   ...
 }
 ```
@@ -59,7 +59,7 @@ if (1) { // 1 es verdadero
 También podemos pasar un valor booleano pre-evaluado al `if`, así:
 
 ```js
-let cond = (year == 2015); // la igualdad evalúa y devuelve un true o false
+let cond = (year == 2015); // la igualdad se evalúa y devuelve un true o false
 
 if (cond) {
   ...
@@ -68,7 +68,7 @@ if (cond) {
 
 ## La cláusula "else"
 
-La sentencia `if` puede contener un bloque `else` ("si no", "en caso contrario") opcional. Este bloque se ejecutará cuando la condición sea falsa.
+La sentencia `if` puede contener un bloque `else` ("si no", "en caso contrario") opcional. Este bloque se ejecuta cuando la condición resulta falsa.
 
 Por ejemplo:
 ```js run
@@ -133,7 +133,7 @@ La Sintaxis es:
 let result = condition ? value1 : value2;
 ```
 
-Se evalúa `condition`: si es verdadera entonces devuelve `value1` , de lo contrario `value2`.
+Se evalúa `condition`: si resulta verdadera entonces devuelve `value1` , de lo contrario `value2`.
 
 Por ejemplo:
 

--- a/1-js/02-first-steps/11-logical-operators/1-alert-null-2-undefined/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/1-alert-null-2-undefined/solution.md
@@ -1,4 +1,4 @@
-La respuesta es `2`, ese es el primer valor verdadero.
+La respuesta es `2`, ese es el primer valor truthy.
 
 ```js run
 alert( null || 2 || undefined );

--- a/1-js/02-first-steps/11-logical-operators/2-alert-or/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/2-alert-or/solution.md
@@ -4,10 +4,10 @@ La repuesta: primero `1`, después `2`.
 alert( alert(1) || 2 || alert(3) );
 ```
 
-La llamada a `alert` no retorna un valor. O, en otras palabras, retorna `undefined`.
+Una llamada a `alert` no retorna un valor relevante. Siempre retorna `undefined`.
 
-1. El primer OR `||` evalúa el operando de la izquierda `alert(1)`. Eso muestra el primer mensaje con `1`.
-2. El `alert` retorna `undefined`, por lo que OR se dirige al segundo operando buscando un valor verdadero.
-3. El segundo operando `2` es un valor verdadero, por lo que se detiene la ejecución, se retorna `2` y es mostrado por el alert exterior.
+1. El primer OR `||` comienza evaluando el operando de la izquierda `alert(1)`. Este alert muestra el primer mensaje con `1`.
+2. Ese mismo `alert` retorna `undefined`, por lo que OR se dirige al segundo operando buscando un valor truthy.
+3. El segundo operando `2` es un valor truthy, por lo que el OR detiene su ejecución y retorna el 2. Este 2 es luego mostrado por el alert exterior.
 
-No habrá `3` debido a que la evaluación no alcanza a `alert(3)`.
+No habrá `3` debido a que la evaluación nunca alcanza a `alert(3)`.

--- a/1-js/02-first-steps/11-logical-operators/3-alert-1-null-2/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/3-alert-1-null-2/solution.md
@@ -1,4 +1,4 @@
-La respuesta: `null`, porque es el primer valor falso de la lista.
+La respuesta: `null`, porque es el primer valor falsy de la lista.
 
 ```js run
 alert(1 && null && 2);

--- a/1-js/02-first-steps/11-logical-operators/4-alert-and/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/4-alert-and/solution.md
@@ -4,6 +4,6 @@ La respuesta: `1` y después `undefined`.
 alert( alert(1) && alert(2) );
 ```
 
-La llamada a `alert` retorna `undefined` (solo muestra un mensaje, así que no hay un valor que retornar relevante)
+Una llamada a `alert` siempre retorna `undefined` (solo muestra un mensaje, no tiene un valor relevante que retornar)
 
-Debido a ello, `&&` evalúa el operando de la izquierda (imprime `1`) e inmediatamente se detiene porque `undefined` es un valor falso. Como `&&` busca un valor falso y lo retorna, terminamos.
+Debido a ello, `&&` evalúa el operando de la izquierda (el cual imprime `1`) e inmediatamente se detiene porque `undefined` es falsy. Como `&&` busca un valor falsy, lo retorna y termina.

--- a/1-js/02-first-steps/11-logical-operators/5-alert-and-or/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/5-alert-and-or/solution.md
@@ -12,5 +12,5 @@ El resultado de `2 && 3 = 3`, por lo que la expresión se convierte en:
 null || 3 || 4
 ```
 
-Ahora el resultado será el primer valor verdadero: `3`.
+Ahora el resultado será el primer valor truthy: `3`.
 

--- a/1-js/02-first-steps/11-logical-operators/8-if-question/solution.md
+++ b/1-js/02-first-steps/11-logical-operators/8-if-question/solution.md
@@ -4,11 +4,11 @@ Detalles:
 
 ```js run
 // Corre.
-// El resultado de -1 || 0 = -1, valor verdadero
+// El resultado de -1 || 0 es -1, valor truthy
 if (-1 || 0) alert( "primero" );
 
 // No corre.
-// -1 && 0 = 0, valor falso
+// -1 && 0 es 0, valor falsy
 if (-1 && 0) alert( "segundo" );
 
 // Se ejecuta

--- a/1-js/02-first-steps/11-logical-operators/9-check-login/task.md
+++ b/1-js/02-first-steps/11-logical-operators/9-check-login/task.md
@@ -6,12 +6,12 @@ importance: 3
 
 Escribe un código que pregunte por el inicio de sesión con `propmt`.
 
-Si el visitante ingresa `"Admin"`, entonces `prompt`(pregunta) por una contraseña, si la entrada es una linea vacía o `key:Esc` -- muestra "Cancelado.", si es otra cadena de texto -- entonces muestra "No te conozco".
+Si el visitante ingresa `"Admin"`, entonces pregunta por una contraseña con otro `prompt`. Si la entrada es una linea vacía o `key:Esc`, entonces muestra "Cancelado.", si es otra cadena de texto, entonces muestra "No te conozco".
 
 La contraseña se comprueba de la siguiente manera:
 
 -  Si es igual a "TheMaster", entonces muestra "Bienvenido!",
--  Si es otra cadena de texto -- muetra "Contraseña incorrecta",
+-  Si es otra cadena de texto, muetra "Contraseña incorrecta",
 -  Para una cadena de texto vacía o una entrada cancelada, muestra "Cancelado."
 
 El esquema:

--- a/1-js/02-first-steps/11-logical-operators/9-check-login/task.md
+++ b/1-js/02-first-steps/11-logical-operators/9-check-login/task.md
@@ -6,7 +6,7 @@ importance: 3
 
 Escribe un código que pregunte por el inicio de sesión con `propmt`.
 
-Si el visitante ingresa `"Admin"`, entonces pregunta por una contraseña con otro `prompt`. Si la entrada es una linea vacía o `key:Esc`, entonces muestra "Cancelado.", si es otra cadena de texto, entonces muestra "No te conozco".
+Si el visitante ingresa `"Admin"`, entonces debe pedir una contraseña (con un nuevo `propmt`). Si la entrada es una linea vacía o `key:Esc`, entonces muestra "Cancelado.". Si es otra cadena de texto, entonces muestra "No te conozco".
 
 La contraseña se comprueba de la siguiente manera:
 

--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -35,7 +35,7 @@ Por ejemplo, el número `1` es tratado como `true`, el número `0` como `false`:
 
 ```js run
 if (1 || 0) { // Funciona como if( true || false )
-	alert("valor verdadero!");
+	alert("¡valor truthy!");
 }
 ```
 
@@ -94,14 +94,14 @@ alert(1 || 0); // 1 (1 es un valor verdadero)
 alert(null || 1); // 1 (1 es el primer valor verdadero)
 alert(null || 0 || 1); // 1 (el primer valor verdadero)
 
-alert(undefined || null || 0); // 0 (todos son valores falsos, retorna el último valor)
+alert(undefined || null || 0); // 0 (todos son valores falsy, retorna el último valor)
 ```
 
 Esto brinda varios usos interesantes comparados al "OR puro, clásico, de solo booleanos".
 
 1. **Obtener el primer valor verdadero de una lista de variables o expresiones.**
 
-   Por ejemplo, tenemos las variables `firstName`, `lastName` y `nickName`, todas opcionales (pueden ser undefined o tener valores falsos).
+   Por ejemplo, tenemos las variables `firstName`, `lastName` y `nickName`, todas opcionales (pueden ser undefined o tener valores falsy).
 
    Usemos OR `||` para elegir el que tiene los datos y mostrarlo (o anónimo si no hay nada configurado):
 
@@ -115,7 +115,7 @@ Esto brinda varios usos interesantes comparados al "OR puro, clásico, de solo b
    */!*
    ```
 
-    Si todas las variables fueran falsas, aparecería `"Anonymous"`. 
+    Si todas las variables fueran falsy, aparecería `"Anonymous"`. 
 
 2. **Evaluación del camino más corto.**
 
@@ -134,7 +134,7 @@ Esto brinda varios usos interesantes comparados al "OR puro, clásico, de solo b
 
     En la primera línea, el operador OR `||` detiene la evaluación inmediatamente después de ver que es verdadera, por lo que la alerta no se ejecuta.
 
-    A veces se usa esta función para ejecutar comandos solo si la condición en la parte izquierda es falsa.
+    A veces se usa esta función para ejecutar comandos solo si la condición en la parte izquierda es falsy.
 
 ## && (AND)
 
@@ -168,11 +168,11 @@ Al igual que con OR, cualquier valor es permitido como operando de AND:
 
 ```js run
 if (1 && 0) { // evaluado como true && false
-  alert( "no funcionará porque el resultado es un valor falso" );
+  alert( "no funcionará porque el resultado es un valor falsy" );
 }
 ```
 
-## AND "&&" encuentra el primer valor falso
+## AND "&&" encuentra el primer valor falsy
 
 Dado múltiples valores aplicados al operador AND:
 
@@ -184,27 +184,27 @@ El operador AND `&&` realiza lo siguiente:
 
 -  Evalúa los operandos de izquierda a derecha.
 -  Para cada operando, los convierte a un booleano. Si el resultado es `false`, se detiene y retorna el valor original de dicho operando.
--  Si todos los operandos han sido evaluados (todos fueron valores verdaderos), retorna el último operando.
+-  Si todos los operandos han sido evaluados (todos fueron valores truthy), retorna el último operando.
 
-En otras palabras, AND retorna el primer valor falso o el último valor si ninguno fue encontrado.
+En otras palabras, AND retorna el primer valor falsy o el último valor si ninguno fue encontrado.
 
-Las reglas anteriores son similares a las de OR. La diferencia es que AND retorna el primer valor *falso* mientras que OR retorna el primer valor *verdadero*.
+Las reglas anteriores son similares a las de OR. La diferencia es que AND retorna el primer valor *falsy* mientras que OR retorna el primer valor *truthy*.
 
 Ejemplo:
 
 ```js run
-// si el primer operando es un valor verdadero,
+// si el primer operando es un valor truthy,
 // AND retorna el segundo operando:
 alert(1 && 0); // 0
 alert(1 && 5); // 5
 
-// si el primer operando es un valor falso,
+// si el primer operando es un valor falsy,
 // AND lo retorna. El segundo operando es ignorado
 alert(null && 5); // null
 alert(0 && "cualquier valor"); // 0
 ```
 
-También podemos pasar varios valores de una vez. Observa como el primer valor falso es retornado: 
+También podemos pasar varios valores de una vez. Observa como el primer valor falsy es retornado: 
 
 ```js run
 alert(1 && 2 && null && 3); // null


### PR DESCRIPTION
Por un error de traducción, 
se ignoraron los conceptos truthy y falsy y se los mostraba como sinonimos de tru false.

Dejo el termino inglés porque no hay traduccion adecuada  (¿"falsejo" ? ¿"verdaderito"?)
y es el que usa MDN español
